### PR TITLE
Fixed removing link process in Q_Utils::symlink. If the source link n…

### DIFF
--- a/platform/classes/Q/Utils.php
+++ b/platform/classes/Q/Utils.php
@@ -1791,13 +1791,11 @@ class Q_Utils
 			return;
 		}
 
-		if (file_exists($link)) {
+		if (is_link($link)) {
 			if ($skipIfExists) {
 				return false;
 			}
-			if (is_dir($link)) {
-				rmdir($link);
-			} else if (is_link($link)) {
+			if (!rmdir($link)) {
 				unlink($link);
 			}
 		}


### PR DESCRIPTION
…ot exists, file_exists and is_dir and is_file return false. So we can't detect whether it's dir or file and also file_exists return false. But is_link return true. And rmdir on non dir will not lead to fault error, but just return false. So we process only links and try rmdir and if false try unlink.