### PR TITLE
Fix Node socket startup crashes from missing platform stubs

### DIFF
--- a/platform/classes/Q.js
+++ b/platform/classes/Q.js
@@ -2916,6 +2916,12 @@ Q.init = function _Q_init(app, noServers) {
 	 */
 	Q.Request = require('./Q/Request');
 	/**
+	 * Reference to Q.Response class
+	 * @property Response
+	 * @type {object}
+	 */
+	Q.Response = require('./Q/Response');
+	/**
 	 * Reference to Q.Socket class
 	 * @property Socket
 	 * @type {object}

--- a/platform/classes/Q/Response.js
+++ b/platform/classes/Q/Response.js
@@ -1,0 +1,41 @@
+/**
+ * @module Q
+ */
+
+var _cacheInvalidations = [];
+
+/**
+ * Server-side response utilities (mirrors Q_Response PHP class subset).
+ * @class Response
+ * @namespace Q
+ */
+var Response = {};
+
+/**
+ * Register dependency invalidations to send to the parent server.
+ *
+ * Called after a write operation that modifies a stream dependency.
+ * Mirrors Q_Response::invalidateCacheDeps in PHP.
+ *
+ * @method invalidateCacheDeps
+ * @static
+ * @param {string|Array} keys Stream identifiers to invalidate
+ */
+Response.invalidateCacheDeps = function (keys) {
+	if (!Array.isArray(keys)) {
+		keys = [keys];
+	}
+	_cacheInvalidations.push.apply(_cacheInvalidations, keys);
+};
+
+/**
+ * Get accumulated cache invalidations (for inspection/debugging).
+ * @method cacheInvalidations
+ * @static
+ * @return {Array}
+ */
+Response.cacheInvalidations = function () {
+	return _cacheInvalidations.slice();
+};
+
+module.exports = Response;

--- a/platform/classes/Q/Socket.js
+++ b/platform/classes/Q/Socket.js
@@ -77,6 +77,14 @@ function Socket (server, options) {
 
 var _listening = false;
 
+function _registerEvents(client) {
+	if (client.alreadyListeningQ) {
+		return;
+	}
+	client.alreadyListeningQ = true;
+	// no core events for now, but this is where we would register them if we had any
+}
+
 /**
  * Start http server if needed and start listening to socket
  * @method listen


### PR DESCRIPTION
Add _registerEvents in Q.Socket for the cacheDeps connection handler, and introduce Q/Response.js with invalidateCacheDeps so Streams can invalidate cache deps on the Node side without throwing ReferenceError/TypeError.