### PR TITLE
Q/expandable: scroll only the tool's own scrolling parent on collapse

### DIFF
--- a/platform/plugins/Q/web/js/tools/expandable.js
+++ b/platform/plugins/Q/web/js/tools/expandable.js
@@ -266,7 +266,40 @@ Q.Tool.define('Q/expandable', function (options) {
             tool.stateChanged("expanded");
 
             if (!options || !options.dontScrollIntoView) {
-                tool.element.scrollIntoView({behavior: "smooth"});
+                // Deliberately not Element.prototype.scrollIntoView(): that
+                // scrolls every scrollable ancestor, including ones whose
+                // overflow is hidden. Such an element still scrolls from
+                // script, but offers the user no scrollbar and no touch
+                // gesture to scroll it back, so whatever it shifts stays
+                // shifted. Inside a Q/columns column that is exactly what
+                // happens -- the column's slot is the intended scroller while
+                // <body> above it carries Q_overflowHidden -- and collapsing
+                // an expandable there shears the column title permanently off
+                // the top of the viewport. Scroll the tool's own scrolling
+                // parent instead; scrollable() already skips overflow: hidden
+                // when it picks one, and expand() scrolls the same element.
+                var $scrollable = tool.scrollable();
+                if ($scrollable.length) {
+                    var s = $scrollable[0];
+                    var isBody = ["BODY", "HTML"]
+                        .indexOf(s.tagName.toUpperCase()) >= 0;
+                    // For the document scroller the visible band is the
+                    // viewport, not the element's own rect (whose top is
+                    // -scrollTop).
+                    var sr = s.getBoundingClientRect();
+                    var visibleTop = isBody ? 0 : sr.top;
+                    var visibleBottom = isBody
+                        ? (window.innerHeight || document.documentElement.clientHeight)
+                        : sr.bottom;
+                    var er = tool.element.getBoundingClientRect();
+                    if (er.top < visibleTop) {
+                        s.scrollTop += er.top - visibleTop;
+                    } else if (er.bottom > visibleBottom) {
+                        s.scrollTop += Math.min(
+                            er.top - visibleTop, er.bottom - visibleBottom
+                        );
+                    }
+                }
             }
 
             Q.handle(callback, tool, []);


### PR DESCRIPTION
## The bug

`Q/expandable`'s `collapse()` ends its animation with:

```js
tool.element.scrollIntoView({behavior: "smooth"});
```

`scrollIntoView` scrolls **every** scrollable ancestor, not just the one the element actually scrolls inside. An ancestor with `overflow: hidden` is still scrollable from script — it simply has no scrollbar and accepts no touch — so anything it shifts stays shifted, with no gesture available to put it back.

Inside a `Q/columns` column that is exactly the situation. `.Q_column_slot` is the intended scroller, while `<body>` above it carries `Q_overflowHidden` (applied by `columns.js`) along with a few tens of pixels of overflow. Collapsing an expandable scrolls body, and the column title is sheared off the top of the viewport permanently.

Measured on a profile column at 375x812, collapsing one section:

| | `body.scrollTop` | `.Q_columns_title` top |
|---|---|---|
| before | 0 | +21 |
| after | **42** | **−21** |

It never self-corrects — re-expanding the section leaves body at 42. The column's close X still works, since it is a click target rather than a scroll target, which is why this reads to users as a rendering bug rather than a scroll one.

## The change

Scroll the tool's own scrolling parent instead of every ancestor.

`tool.scrollable()` already picks the right element — it goes through `Element.scrollingParent(true, "vertical")`, which explicitly skips `overflow: hidden` — and `expand()` already scrolls that same element. So this also makes the two directions symmetric, where before one was contained and the other was not.

The document scroller is special-cased to the viewport band, because `documentElement`'s own rect top is `-scrollTop` rather than 0. `expand()` carries the equivalent `isBody` special case, and this follows it.

## Verification

Against a live Qbix app at a 375x812 mobile viewport, driving a real tap on the section header, with only this file swapped between the two runs:

```
[UPSTREAM] before            {"body":0,"titleTop":21}
[UPSTREAM] collapsed         {"body":42,"titleTop":-21}   <- clipped
[UPSTREAM] re-expanded       {"body":42,"titleTop":-21}   <- stays clipped

[PATCHED]  before            {"body":0,"titleTop":21}
[PATCHED]  collapsed         {"body":0,"titleTop":21}
[PATCHED]  re-expanded       {"body":0,"titleTop":21}
```

Collapse and expand both still behave normally with the patch.

One caveat worth stating plainly: the exercised path is the one where the scrolling parent is a container (`.Q_column_slot`). The `isBody` branch — an expandable on a page where the document itself scrolls — is reasoned from `expand()`'s existing handling of the same case, not exercised by the above.