### PR TITLE
Q_Response::setMeta(): clear stale og:image companion tags when a later image can't be sized

### DIFF
--- a/platform/classes/Q/Response.php
+++ b/platform/classes/Q/Response.php
@@ -587,6 +587,42 @@ class Q_Response
 					array('name' => 'property', 'value' => 'og:image:secure_url', 'content' => $params['content']),
 					array('name' => 'property', 'value' => 'og:image:type', 'content' => $size['mime'])
 				));
+			} else {
+				// og:image itself is keyed by name:value below, so a later call
+				// REPLACES an earlier one -- but these four companions were only
+				// ever written, never cleared. So when a page set a sizeable
+				// og:image first (the app default) and an unsizeable one second
+				// (a stream icon, missing or remote), the survivors described the
+				// image that lost: og:image:secure_url pointed at the default
+				// while og:image pointed at the icon, and the width/height/type
+				// described neither. Unfurlers that prefer secure_url then showed
+				// the wrong image entirely.
+				//
+				// og:image stands alone perfectly well without them, so drop the
+				// stale set rather than leave it describing another image.
+				self::clearMeta(array(
+					'property:og:image:width',
+					'property:og:image:height',
+					'property:og:image:secure_url',
+					'property:og:image:type'
+				));
+			}
+		}
+	}
+
+	/**
+	 * Removes previously set meta tags, by their "name:value" keys,
+	 * from the global set and from every slot that carries them.
+	 * @method clearMeta
+	 * @static
+	 * @param {string|array} $keys One key like "property:og:image:width", or an array of them
+	 */
+	static function clearMeta($keys)
+	{
+		foreach ((array)$keys as $key) {
+			unset(self::$metas[$key]);
+			foreach (self::$metasForSlot as $slot => $metas) {
+				unset(self::$metasForSlot[$slot][$key]);
 			}
 		}
 	}


### PR DESCRIPTION
A page that sets `og:image` twice can end up advertising companion tags that describe the image that *lost*.

### Cause

`setMeta()` derives four companions whenever an `og:image` is set and `getimagesize()` succeeds:

```php
if (is_array($size) && !empty($size[0]) && !empty($size[1])) {
    self::setMeta(array(
        array(... "og:image:width",      $size[0]),
        array(... "og:image:height",     $size[1]),
        array(... "og:image:secure_url", $params["content"]),
        array(... "og:image:type",       $size["mime"])
    ));
}
```

`og:image` itself is stored as `self::$metas[$key]` keyed by `name:value`, so a second call **replaces** the first. The four companions are only ever written, never cleared — and only written when the size lookup succeeds.

So when a page sets a sizeable `og:image` first (an app default on local disk) and an unsizeable one second (a stream icon that is missing, or a remote URL), the survivors are the first image's:

```html
<meta property="og:image:width"      content="400">
<meta property="og:image:height"     content="400">
<meta property="og:image:secure_url" content="https://example.com/img/icon/400.png">
<meta property="og:image:type"       content="image/png">
<meta property="og:image"            content="https://example.com/.../icon/1787355937/1000x.jpg">
```

`og:image:secure_url` names a different image from `og:image`, and the declared 400×400 / `image/png` describes neither. Unfurlers that prefer `secure_url` show the wrong image entirely; the rest advertise wrong dimensions.

### Fix

`og:image` is well-formed on its own, so clear the stale set rather than leave it describing another image. Adds `Q_Response::clearMeta()`, which removes metas by key from both the global set and every slot.

Verified against a live install: with a correctly sized image the companions are rewritten as before (`1000`/`1000`/`image/jpeg`, `secure_url` == `og:image`); with an unsizeable one they are now absent rather than stale.