### PR TITLE
Q/Valid, Q/Utils: fail closed when Q/internal/secret is not configured

### DIFF
--- a/platform/classes/Q/Utils.js
+++ b/platform/classes/Q/Utils.js
@@ -19,48 +19,25 @@ var Db_Mysql = Q.require('Db/Mysql');
 var Utils = {};
 
 /**
- * Generate a local secret that is stable but hard to guess from outside.
- * Mirrors Q_Utils::generateLocalSecret() in PHP.
- * @method generateLocalSecret
+ * Returns the configured Q/internal/secret, or throws.
+ * Mirrors Q_Utils::requireInternalSecret() in PHP, including treating the empty
+ * string and the "TODO: ..." placeholder that local.sample ships as
+ * unconfigured -- that placeholder is published in every copy of this
+ * repository, so an install that keeps it holds a secret every attacker already
+ * has, and can therefore sign with it.
+ * @method requireInternalSecret
  * @private
  * @return {string}
  */
-function generateLocalSecret() {
-	var os = require('os');
-	var child_process = require('child_process');
-
-	var parts = [
-		os.hostname(),
-		process.platform === 'win32' ? 'WINNT' : os.type(),
-		Q.app.DIR
-	];
-
-	try {
-		if (process.platform === 'win32') {
-			try {
-				var output = child_process.execSync(
-					'reg query "HKLM\\SOFTWARE\\Microsoft\\Cryptography" /v MachineGuid',
-					{
-						encoding: 'utf8',
-						stdio: ['ignore', 'pipe', 'ignore']
-					}
-				);
-
-				var m = output.match(/MachineGuid\s+REG_SZ\s+([^\r\n]+)/i);
-				if (m) {
-					parts.push(m[1].trim());
-				}
-			} catch (e) {}
-		} else {
-			if (fs.existsSync('/etc/machine-id')) {
-				parts.push(fs.readFileSync('/etc/machine-id', 'utf8').trim());
-			}
+function requireInternalSecret() {
+	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
+	if (typeof secret === 'string') {
+		secret = secret.trim();
+		if (secret !== '' && secret.substr(0, 5) !== 'TODO:') {
+			return secret;
 		}
-	} catch (e) {}
-
-	return crypto.createHash('sha256')
-		.update(parts.join("\t"))
-		.digest('hex');
+	}
+	throw new Error('Q/internal/secret is not configured');
 }
 
 function ksort(obj) {
@@ -132,10 +109,7 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
  * @return {string}
  */
 Utils.signature = function (data, secret) {
-	secret = secret || Q.Config.get(['Q', 'internal', 'secret'], null);
-	if (!secret) {
-		secret = generateLocalSecret();
-	}
+	secret = secret || requireInternalSecret();
 	if (typeof(data) !== 'string') {
 		data = http_build_query(ksort(data)).replace(/\+/g, '%20');
 	}
@@ -150,10 +124,7 @@ Utils.signature = function (data, secret) {
  * @return {object} The data object is mutated and returned
  */
 Utils.sign = function (data, fieldKeys) {
-	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
-	if (!secret) {
-		secret = generateLocalSecret();
-	}
+	var secret = requireInternalSecret();
 	if (!fieldKeys || !fieldKeys.length) {
 		var sf = Q.Config.get(['Q', 'internal', 'sigField'], 'sig');
 		fieldKeys = ['Q.'+sf];
@@ -177,14 +148,12 @@ Utils.sign = function (data, fieldKeys) {
  * @method validate
  * @param {object} data the signed data to validate
  * @param {array} fieldKeys Optionally specify the array key path for the signature field
- * @return {boolean} Whether the signature is valid. Returns true if secret is empty.
+ * @return {boolean} Whether the signature is valid.
+ * @throws {Error} if "Q"/"internal"/"secret" is not configured
  */
 Utils.validate = function(data, fieldKeys) {
 	var temp = Q.copy(data, null, 100);
-	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
-	if (!secret) {
-		secret = generateLocalSecret();
-	}
+	var secret = requireInternalSecret();
 	if (!fieldKeys || !fieldKeys.length) {
 		var sf = Q.Config.get(['Q', 'internal', 'sigField'], 'sig');
 		fieldKeys = ['Q.'+sf];

--- a/platform/classes/Q/Utils.php
+++ b/platform/classes/Q/Utils.php
@@ -338,10 +338,7 @@ class Q_Utils
 	static function signature($data, $secret = null)
 	{
 		if (!isset($secret)) {
-			$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		}
-		if (!isset($secret)) {
-			$secret = Q_Utils::generateLocalSecret();
+			$secret = self::requireInternalSecret();
 		}
 		if (is_array($data)) {
 			$data = self::serialize($data);
@@ -361,10 +358,7 @@ class Q_Utils
 	 */
 	static function sign($data, $fieldKeys = null, $secret = null) {
 		if (!isset($secret)) {
-			$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		}
-		if (!isset($secret)) {
-			$secret = Q_Utils::generateLocalSecret();
+			$secret = self::requireInternalSecret();
 		}
 		if (!$fieldKeys) {
 			$sf = Q_Config::get('Q', 'internal', 'sigField', 'sig');
@@ -387,34 +381,28 @@ class Q_Utils
 	}
 
 	/**
-	 * Generate a local secret that is stable but hard to guess from outside
-	 * @method generateLocalSecret
+	 * Returns the configured "Q"/"internal"/"secret", or throws.
+	 * The empty string and the "TODO: ..." placeholder that local.sample ships
+	 * count as unconfigured -- the placeholder is a fixed value published in
+	 * every copy of this repository, so an install that keeps it holds a secret
+	 * every attacker already has and can therefore sign with.
+	 * @method requireInternalSecret
 	 * @static
+	 * @return {string}
+	 * @throws {Q_Exception_MissingConfig}
 	 */
-	protected static function generateLocalSecret()
+	static function requireInternalSecret()
 	{
-		$parts = array(
-			gethostname(),
-			PHP_OS,
-			APP_DIR
-		);
-
-		if (self::isWindows()) {
-			$guid = trim((string) @shell_exec(
-				'reg query "HKLM\SOFTWARE\Microsoft\Cryptography" /v MachineGuid 2>NUL'
-			));
-
-			if (preg_match('/MachineGuid\s+REG_SZ\s+([^\r\n]+)/i', $guid, $matches)) {
-				$parts[] = trim($matches[1]);
-			}
-		} else {
-			$machineIdFile = '/etc/machine-id';
-			if (is_readable($machineIdFile)) {
-				$parts[] = trim(file_get_contents($machineIdFile));
+		$secret = Q_Config::get('Q', 'internal', 'secret', null);
+		if (is_string($secret)) {
+			$secret = trim($secret);
+			if ($secret !== '' and !Q::startsWith($secret, 'TODO:')) {
+				return $secret;
 			}
 		}
-
-		return hash('sha256', implode("\t", $parts));
+		throw new Q_Exception_MissingConfig(array(
+			'fieldpath' => 'Q/internal/secret'
+		));
 	}
 
 	/**

--- a/platform/classes/Q/Valid.php
+++ b/platform/classes/Q/Valid.php
@@ -350,10 +350,25 @@ class Q_Valid
 			$data = $_REQUEST;
 		}
 		if (!isset($secret)) {
-			$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		}
-		if (!isset($secret)) {
-			return true;
+			// Fail CLOSED. This used to `return true` -- with no internal secret
+			// configured, EVERY payload validated, so an unsigned or forged
+			// request passed every gate built on this: handlers/Q/config/validate.php
+			// (which writes config onto the machine), Streams::invites(),
+			// Media/callCenter. A validator must never read "no key" as "valid".
+			//
+			// This is safe to reject because Q_Utils::signature()/sign() now throw
+			// in the same circumstance rather than quietly HMAC-ing with a
+			// machine-derived string, so a misconfigured app fails loudly at its
+			// first request instead of being silently locked out.
+			try {
+				$secret = Q_Utils::requireInternalSecret();
+			} catch (Q_Exception_MissingConfig $e) {
+				if ($throwIfInvalid) {
+					Q_Response::code(403);
+					throw $e;
+				}
+				return false;
+			}
 		}
 		$invalid = true;
 		if (is_array($fieldKeys)) {


### PR DESCRIPTION
Q/Valid, Q/Utils: fail closed when Q/internal/secret is not configured

Internal request signing is fail-open when "Q"/"internal"/"secret" is unset,
in two different ways.

1. Q_Valid::signature() returns TRUE for every payload:

       if (!isset($secret)) {
           return true;
       }

   It is a validator, and it reads "no key" as "valid". Everything built on it
   is an internal gate -- handlers/Q/config/validate.php, which writes config
   onto the machine; Streams::invites(); Media/callCenter -- so an install that
   has not set the secret accepts forged internal requests while looking
   healthy. All three of those call sites pass $throwIfInvalid = true, so the
   rejection surfaces as the existing Q_Response::code(403), with
   Q_Exception_MissingConfig naming the key at fault rather than blaming the
   caller for a local misconfiguration.

2. Q_Utils::signature() and Q_Utils::sign() fall back to
   generateLocalSecret(), a sha256 of gethostname(), PHP_OS, APP_DIR and
   /etc/machine-id (or the Windows MachineGuid). Every component is public or
   identical across hosts deployed from the same image, so it is a secret in
   name only, and callers cannot tell they were handed one instead of the
   configured key. It also differs between the PHP host and the Node host, so
   PHP <-> Node internal signing silently never verifies.

Rejecting on the verifying side is only safe together with failing loudly on
the signing side -- otherwise a silent hole is traded for a silent lockout:
sign, hand out something no peer can verify, and see no error anywhere. So both
halves move together, and generateLocalSecret() is deleted rather than left
unused.

Q_Utils::requireInternalSecret() also treats the empty string and the
"TODO: CHANGE TO SOME RANDOM STRING, ..." literal that local.sample/app.json
ships as unconfigured. That literal is a fixed value published in every copy of
this repository, so an install that keeps it is not weakly configured -- it
holds a secret every attacker already has, and can therefore sign.

platform/classes/Q/Utils.js carries the identical fallback in signature(),
sign() and validate(), whose docblock advertised "Returns true if secret is
empty". Fixed the same way so the two runtimes agree.

Behaviour with a secret configured is unchanged: every path that passes an
explicit $secret, and every path reading a real configured secret, is untouched.
