### PR TITLE
Redact frame arguments from any backtrace that reaches a client

### DIFF
--- a/platform/classes/Q/Exception.php
+++ b/platform/classes/Q/Exception.php
@@ -254,6 +254,49 @@ class Q_Exception extends Exception
 	}
 	
 	/**
+	 * Removes the arguments from every frame of a PHP backtrace, leaving the
+	 * frame's file, line, function and class.
+	 *
+	 * buildArray() is the boundary at which a trace stops being a server-side
+	 * diagnostic and becomes part of a response body, and a frame's "args" is
+	 * the whole of the frame that can carry a secret: PHP records the actual
+	 * values every function was called with, so a trace through, say,
+	 * Users_User::addMobile() carries the Users_User object itself. Db_Row
+	 * declares `public $fields`, so json_encode() of one writes every column —
+	 * sessionId, salt, passphraseHash — into the JSON, and the same is true of
+	 * any plaintext passphrase, token or key that happens to be an argument on
+	 * the way down.
+	 *
+	 * The redaction is unconditional rather than a new config key, and that is
+	 * the point. `Q/exception/showTrace` already exists to keep traces out of
+	 * responses, and it is off by default — but Q_Exception.php reads it with a
+	 * fallback of TRUE, apps have shipped it as true, and it is on wherever
+	 * APP_DEBUG is. A flag that can turn a credential disclosure back on is
+	 * a failure mode that recurs in practice, so
+	 * args are removed on the path that reaches a client no matter how the
+	 * flag is set. Nothing is lost server-side: getTraceAsString(), which is
+	 * what logging and Q_Exception::coloredString() use, renders arguments as
+	 * `Object(Users_User)` and truncated scalars, and is untouched here.
+	 *
+	 * @method redactTrace
+	 * @static
+	 * @param {array} $trace A backtrace as returned by Exception::getTrace()
+	 * @return {array} the same frames, each without its "args" key
+	 */
+	static function redactTrace($trace)
+	{
+		if (!is_array($trace)) {
+			return $trace;
+		}
+		foreach ($trace as $i => $frame) {
+			if (is_array($frame)) {
+				unset($trace[$i]['args']);
+			}
+		}
+		return $trace;
+	}
+
+	/**
 	 * Converts an exception or array of exceptions to an array
 	 * @method buildArray
 	 * @static
@@ -290,6 +333,7 @@ class Q_Exception extends Exception
 				} else {
 					$trace = $e->getTrace();
 				}
+				$trace = self::redactTrace($trace);
 			}
 			$params = null;
 			if (is_callable(array($e, 'params'))) {

--- a/platform/classes/Q/RemoteController.php
+++ b/platform/classes/Q/RemoteController.php
@@ -57,7 +57,13 @@ class Q_RemoteController
 					'params' => [$e->getMessage(), $e->getCode()],
 					'file' => $e->getFile(),
 					'line' => $e->getLine(),
-					'backtrace' => array_slice($e->getTrace(), 0, 20)
+					// Redacted: a raw getTrace() carries every frame's actual
+					// arguments, so any row, passphrase or key on the way down
+					// would be serialized into this response body. See
+					// Q_Exception::redactTrace().
+					'backtrace' => Q_Exception::redactTrace(
+						array_slice($e->getTrace(), 0, 20)
+					)
                 )
             ));
 		}


### PR DESCRIPTION
`Q_Exception::buildArray()` is the boundary at which an exception stops being a server-side diagnostic and becomes a response body — `handlers/Q/errors.php` json_encodes its output for every AJAX request, and the Streams and Assets batch handlers embed it per sub-request. It puts `Exception::getTrace()` in there verbatim, and **a PHP backtrace frame records the actual values every function was called with**, not just its name.

## What that discloses

`Users_User::addMobile()` calls `Users_Mobile::sendMessage($view, array('user' => $this, ...))`. On a deployment whose Twilio credentials are wrong, the gateway rejects and the resulting `412` carries a frame whose args hold the `Users_User` object — and `Db_Row` declares `public $fields`, so `json_encode()` of that row writes **every column** into the response:

```json
{"user":{"id":"...","sessionId":"sessionId_authenticated_...","salt":"...","passphraseHash":"..."}}
```

That instance is one path. The general property is that any argument on any failing path is exposed the same way — a plaintext passphrase, a recovery or intent token, an API key.

## Why not fix it on the model

The obvious response is a `__debugInfo`/`__sleep` on `Users_User` dropping the sensitive columns. Neither is consulted by `json_encode`: `__debugInfo` affects `var_dump` only, `__sleep` affects `serialize` only. The leak belongs to the trace serializer.

## Why not a config key

`Q/exception/showTrace` already exists for exactly this and already ships `false` in `platform/config/Q.json` — yet it is on in practice three independent ways: `Q_Exception.php` reads it with a fallback of `true` (so an absent key is not a safe key), the `MyApp` scaffold's `config/app.json` ships it as `true`, and debug deployments set it. A second flag that can turn a credential disclosure back on inherits all of that.

## The change

`Q_Exception::redactTrace()` removes each frame's `args`, keeping `file`, `line`, `class`, `type` and `function` — a trace is still a trace. `buildArray()` and `Q_RemoteController` (the other place a backtrace is json_encoded into a response body) both run their trace through it. Non-array entries and a non-array trace pass through unchanged.

Nothing is lost server-side: `getTraceAsString()`, which is what logging and `Q_Exception::coloredString()` use, renders an object argument as `Object(Users_User)` and truncated scalars, and is untouched.

## Verified

On a local stack with `showTrace` true, the `Users/identifier` mobile path: before, 708 bytes of JSON with `sessionId`, `salt` and `passphraseHash` all present; after, 240 bytes with none of them and the trace's file/line/function intact.

Two files, no API removed, no behaviour change for callers that were not serializing arguments.