### PR TITLE
Q/form: follow a redirect by navigating, not by re-requesting the form's slots

### DIFF
--- a/platform/plugins/Q/web/js/tools/form.js
+++ b/platform/plugins/Q/web/js/tools/form.js
@@ -110,13 +110,31 @@ Q.Tool.define('Q/form', function(options) {
 				}
 				var redirectUrl = Q.getObject('redirect.url', response);
 				if (redirectUrl) {
-					// handle one redirect (if it redirects again, give up)
-					Q.request(redirectUrl, state.slotsToRequest, function (err, data2) {
-						if (err) {
-							return Q.handle(redirectUrl);
-						}
-						_handleResult(data2);
-					});
+					// The server answered the submit by telling the client to go
+					// somewhere else, so this is a NAVIGATION, not an in-place form
+					// result -- hand it to Q.handle and let the destination be loaded
+					// with the slots a page publishes.
+					//
+					// It used to re-request the redirect target with this tool's own
+					// `slotsToRequest`, on the assumption that wherever a form
+					// redirects to also serves the form's slots. That holds for a
+					// same-page result and for nothing else: Users/activate redirects
+					// to the app's home with `slotsToRequest: 'form,user'`, and an app
+					// home publishes neither, so every activation answered
+					// Q_Exception_MissingSlot (424) -- for BOTH slots, which is why
+					// dropping just 'form' would not have fixed it. Q_Response's slot
+					// loop only swallows a missing slot when the response is itself a
+					// redirect, and the destination is not.
+					//
+					// The consequence was not only console noise: `_handleResult` then
+					// ran against an errors payload, so the page kept whatever
+					// client-side state it had. After activation that means a STALE
+					// Q.Users.loggedInUser until the next full document load, which
+					// anything reading it in between -- an onLogin handler, a dashboard
+					// rendering from it -- reads as pre-activation state. A real
+					// navigation loads the destination and its session extras.
+					Q.handle(redirectUrl);
+					return false;
 				} else {
 					_handleResult(data);
 				}


### PR DESCRIPTION
`Q/form` submits with `ignoreRedirect: true`, so the loader does not follow a redirect — the tool did, itself:

```js
Q.request(redirectUrl, state.slotsToRequest, function (err, data2) {
    if (err) { return Q.handle(redirectUrl); }
    _handleResult(data2);
});
```

That assumes wherever a form redirects to also serves the form's own slots. It holds for a same-page result and for nothing else.

## What it breaks in the shipped code

`Users/content/activate.php` declares `slotsToRequest: 'form,user'` on both of its `Q/form` tools and redirects to `afterActivate`, which resolves to the app's home. An app home publishes neither slot, so **every activation** — the signup link and the `?p=1` password-reset link alike — answers:

```
424 {"errors":[{"message":"missing slot event <App>/home/response/form",
  "code":10005,"classname":"Q_Exception_MissingSlot"}]}
```

Both slots are missing, not just `form`: `…/response/user` is absent on the destination too, so moving the view to `slotsToRequest: 'user'` would fail identically.

Worth noting why the POST itself is fine and only the follow-up 424s: `Users_activate_response()` dispatches `Users/activate/response/content` unconditionally (that is where `Q_Response::redirect()` lives), and `Q/response.php` swallows a missing-slot exception only when the response is itself a redirect. The destination is not.

## Why it is more than console noise

With `errors` in the follow-up payload, `_handleResult` runs against it and the page keeps whatever client state it had. After activation that means `Q.Users.loggedInUser` stays at its **pre-activation** value until the next full document load — so an `onLogin` handler or a dashboard rendering from it reads pre-activation state.

## The change

The server answered the submit by telling the client to go somewhere else, so this is a navigation: `Q.handle(redirectUrl)`. The destination is then loaded with the slots a page actually publishes, and its session extras arrive with it. The error branch already navigated this way, so this makes the two paths agree. The submit's own response and its slots are untouched, and `Users_activate_post()` still fills `form` and `user` for the POST.

## Verified

Against a local stack: with the old branch, the activation flow emits the 424 above (URL `…&Q.slotNames=form%2Cuser`); with this change, the whole activation completes with no 424 and the page's user object reflects the activation without a reload. Full browser suite green either way apart from that assertion.