### PR TITLE
Db.Mysql: survive and recover from fatal connection errors; SET NAMES utf8mb4

### DIFF
--- a/platform/classes/Db/Mysql.js
+++ b/platform/classes/Db/Mysql.js
@@ -13,6 +13,19 @@ var util = require('util');
  * @private
  */
 var connections = {};
+
+/**
+ * Remove a connection from the cache, if it is still the cached one for its
+ * key. Called when a connection errors fatally, so no future query reuses a
+ * dead handle.
+ * @method evictConnection
+ * @private
+ */
+function evictConnection(c) {
+	if (c && c.__qbixKey !== undefined && connections[c.__qbixKey] === c) {
+		delete connections[c.__qbixKey];
+	}
+}
 	
 /**
  * MySQL connection class
@@ -94,6 +107,17 @@ function Db_Mysql(connName, dsn) {
 				return del.call(this, err, sequence);
 			};
 		}
+		connection.__qbixKey = key;
+		// A fatal error leaves this handle permanently dead: the driver then
+		// fails every later command with "Can't add new command when
+		// connection is in closed state". Evict it from the cache so the next
+		// reallyConnect() builds a fresh connection instead of reusing the
+		// corpse forever.
+		connection.on('error', function (err) {
+			if (err && err.fatal) {
+				evictConnection(connection);
+			}
+		});
 		return connections[key] = connection;
 	}
 
@@ -120,6 +144,13 @@ function Db_Mysql(connName, dsn) {
 	dbm.reallyConnect = function(callback, shardName, modifications, dontReconnect) {
 	
 		function _setUpConnection() {
+			// Once per connection object, not once per Db_Mysql: reconnected
+			// or evicted-and-rebuilt connections need their own SET NAMES,
+			// time_zone and error listener too.
+			if (connection.__qbixSetUp) {
+				return;
+			}
+			connection.__qbixSetUp = true;
 			if (Q.Config.get(['Db', 'debug'], false)) {
 				connection._original_query = connection.query;
 				connection.query = function (sql) {
@@ -130,7 +161,15 @@ function Db_Mysql(connName, dsn) {
 					return connection._original_query.apply(connection, arguments);
 				};
 			}
-			dbm.on('error', _Db_Mysql_onConnectionError);
+			// Db/Query/Mysql.js emits query errors on dbm; attach that route
+			// only once per Db_Mysql or handlers would stack up on every
+			// reconnect.
+			if (!dbm.__qbixErrorHandlerAttached) {
+				dbm.__qbixErrorHandlerAttached = true;
+				dbm.on('error', function (err, mq) {
+					_Db_Mysql_onConnectionError(err, mq);
+				});
+			}
 			connection.on('error', _Db_Mysql_onConnectionError);
 			var mt = require('moment-timezone');
 			var timezone = Q.Config.expect(['Q', 'defaultTimezone']);
@@ -140,31 +179,60 @@ function Db_Mysql(connName, dsn) {
 				Math.abs(offset) * 60000 + new Date(2000, 0).getTime()
 		    ).toTimeString();
 		    var tz = (offset < 0 ? '-' : '+') + dt.substring(0,2) + ':' + dt.substring(3,5);
-			connection.query('SET NAMES UTF8; SET time_zone = "'+tz+'"');
+			// utf8mb4, not the utf8mb3 that "UTF8" still aliases in MySQL:
+			// this session reads and writes chat/stream content, and utf8mb3
+			// silently turns 4-byte characters such as emoji into "?". This
+			// also stops overriding the charsetNumber 224 (utf8mb4) that the
+			// connection was opened with.
+			connection.query('SET NAMES utf8mb4; SET time_zone = "'+tz+'"');
 			// Capture the server version from the handshake packet. Connections
 			// live in a module-level cache rather than on dbm, so grab it here
 			// while we have the connection in hand.
 			dbm._connection = connection;
 
 			function _Db_Mysql_onConnectionError(err, mq) {
-				if (err.code === "PROTOCOL_CONNECTION_LOST" && !dontReconnect) {
-					connection = mysqlConnection(
-						info.host,
-						info.port || 3306,
-						info.username,
-						info.password,
-						info.dbname,
-						options,
-						true
-					);
-					connection.connect(function (err) {
-						if (err) {
-							throw new Q.Exception("Db.Mysql connection failed to reconnect to " + connection.config.database, 'mysql')
-							return;
-						}
-						Q.log("Db.Mysql reconnected to " + connection.config.database, 'mysql');
-					});
-					return _setUpConnection();
+				if (err && err.fatal) {
+					// The handle is dead for good (the driver sets fatal on
+					// connection loss AND on every "closed state" command that
+					// follows). Make sure no future query can reuse it.
+					evictConnection(connection);
+				}
+				if (err && err.fatal && !dontReconnect) {
+					// Reconnect at most once per second per Db_Mysql. Without
+					// the throttle, a down MySQL turns each failed attempt's
+					// own fatal error into the next attempt -- a tight loop.
+					if (!dbm.__qbixReconnecting) {
+						dbm.__qbixReconnecting = true;
+						setTimeout(function () {
+							dbm.__qbixReconnecting = false;
+							connection = mysqlConnection(
+								info.host,
+								info.port || 3306,
+								info.username,
+								info.password,
+								info.dbname,
+								options,
+								true
+							);
+							connection.connect(function (err) {
+								if (err) {
+									// Never throw here: an uncaught exception
+									// in this callback crashes the process --
+									// the very outcome reconnecting exists to
+									// prevent. The failed handle is evicted,
+									// so the next query (or the next fatal
+									// error's throttled retry) builds a fresh
+									// connection once MySQL is back.
+									evictConnection(connection);
+									Q.log("Db.Mysql failed to reconnect to " + connection.config.database + ": " + err, 'mysql');
+									return;
+								}
+								Q.log("Db.Mysql reconnected to " + connection.config.database, 'mysql');
+							});
+							_setUpConnection();
+						}, 1000);
+					}
+					return;
 				}
 				Q.log("Db.Mysql error: " + err, 'mysql');
 				if (mq) {
@@ -209,10 +277,10 @@ function Db_Mysql(connName, dsn) {
 			info.dbname,
 			options
 		);
-		if (!dbm.connected) {
-			_setUpConnection();
-			dbm.connected = true;
-		}
+		// Per-connection, not per-dbm: a connection rebuilt after eviction
+		// still needs its SET NAMES, time_zone and error listener.
+		_setUpConnection();
+		dbm.connected = true;
 		// Keep a handle so serverVersion() can read the handshake packet later.
 		// Connections live in a module-level cache, not on dbm.
 		dbm._connection = connection;


### PR DESCRIPTION
## The bugs

Three defects in `Db/Mysql.js`'s connection lifecycle on the Node side — one crash, two silent.

**1. The reconnect path throws inside `connect()`'s callback.** When MySQL is down and the retry fails, `_Db_Mysql_onConnectionError` does:

```js
connection.connect(function (err) {
    if (err) {
        throw new Q.Exception("Db.Mysql connection failed to reconnect to " + ...)
```

A `throw` inside an async callback is an uncaught exception, which `Q.exceptionHandler` turns into `process.exit(1)`. So the reconnection logic — the thing that exists to survive a database outage — is itself what crashes the process the moment MySQL stops. Observed as `UNCAUGHT EXCEPTION 'Db.Mysql connection failed to reconnect'` in a tight restart loop.

**2. A dead handle stays in the module-level `connections` cache forever.** Reconnection only triggers on `PROTOCOL_CONNECTION_LOST`, but the driver marks *many* errors `fatal` (and every subsequent command on a closed connection fails fatally with `Can't add new command when connection is in closed state`). None of those evict the handle from the cache, so every later `mysqlConnection()` call for that key returns the same corpse and nothing ever retries.

**3. `SET NAMES UTF8` downgrades every Node session to utf8mb3.** `UTF8` is still an alias for `utf8mb3` in MySQL 8. The connection is opened with `charsetNumber: 224` (utf8mb4), and this line silently overrides it. Four-byte characters — emoji in chat and stream content — are read and written as `?` from Node while PHP, which uses utf8mb4, handles them fine. Verified against `performance_schema.variables_by_thread`.

## The change

- **Any fatal error evicts the handle from the cache**, via a per-connection `error` listener attached in `mysqlConnection()` and again in `_Db_Mysql_onConnectionError`. The next query builds a fresh connection instead of reusing a dead one.
- **Reconnects are throttled to one attempt per second per `Db_Mysql` and never throw.** A failed attempt logs, evicts, and lets the next query or the next throttled retry recover once MySQL is back.
- **Connection setup is per connection object, not per `Db_Mysql`.** `_setUpConnection()` used to be guarded by `dbm.connected`, so a reconnected or rebuilt connection never got its own `SET NAMES`, time zone, or error listener. It now runs once per connection (guarded on the connection), and the `dbm`-level `error` route that `Db/Query/Mysql.js` emits on is attached once rather than once per reconnect.
- **`SET NAMES utf8mb4`.**

The `dbm._connection` bookkeeping that the vector-search work added is preserved; `_setUpConnection()` still records it, so the rebuilt connection is the one `serverVersion()` reads.

## Verification

On a live stack with the Node process's network to MySQL severed under real socket.io traffic, then restored, with only this file changed between runs:

- **before:** immediate crash loop (`UNCAUGHT EXCEPTION … failed to reconnect`), process restarts continuously until MySQL returns
- **after:** zero process restarts, throttled `Db.Mysql failed to reconnect` log lines once per second, and full delivery recovery when the network came back

utf8mb4: emoji in a chat message round-trips intact through Node; the session's `character_set_client`/`character_set_connection` read `utf8mb4` in `performance_schema.variables_by_thread`.

That verification was done against a build from before the recent `Db` refactors; this is the same change ported onto current `main`, reviewed by hand against the `dbm._connection` additions, and passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
