### PR TITLE
Q.ServiceWorker: fire onActive on every failure path so Q.ready is not starved

### DIFF
--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -11447,6 +11447,22 @@ Q.ServiceWorker = {
 			return callback(true);
 		}
 		Q.ServiceWorker.started = true;
+		// Every path below MUST end in onActive firing (with a worker, or
+		// with false like the not-supported branch above). Q.init pushes a
+		// "serviceWorker" readiness check whenever started is true, and that
+		// check is filled ONLY from onActive -- so an error path that forgets
+		// to fire it leaves Q.ready() permanently un-called: no page
+		// handlers, no hashchange/popstate/resize listeners, and every
+		// Q.page('') feature dead until the first Q.loadUrl navigation.
+		// Registration failures are an everyday occurrence, not a corner
+		// case: Firefox private windows refuse service workers, and some
+		// embedded/automation browser profiles block installation while
+		// fetch() of the same script succeeds.
+		function _failed(error) {
+			console.warn("Q.ServiceWorker.start error", error);
+			Q.handle(callback, Q.ServiceWorker, [false]);
+			Q.handle(Q.ServiceWorker.onActive, Q.ServiceWorker, [false]);
+		}
 		navigator.serviceWorker.getRegistration(src)
 		.then(function (registration) {
 			if (registration && registration.active
@@ -11476,12 +11492,11 @@ Q.ServiceWorker = {
 				if (worker) {
 					Q.handle(callback, Q.ServiceWorker, [worker, registration]);
 					Q.handle(Q.ServiceWorker.onActive, Q.ServiceWorker, [worker, registration]);
+				} else {
+					_failed(new Error("registration returned no worker"));
 				}
-			}).catch(function (error) {
-				callback(error);
-				console.warn("Q.ServiceWorker.start error", error);
-			});
-		});
+			}).catch(_failed);
+		}).catch(_failed);
 
 		var SS_KEY = 'Q.cookieJar';
 
@@ -11550,6 +11565,13 @@ function _startCachingWithServiceWorker() {
 		return false;
 	}
 	Q.ServiceWorker.start(function (worker, registration) {
+		if (!worker || typeof worker.postMessage !== 'function') {
+			// start() reports failure by passing false -- there is no worker
+			// to prime the cache on. Treating the failure value as a worker
+			// was the source of the uncaught "worker.postMessage is not a
+			// function" rejection.
+			return;
+		}
 		var items = [];
 		var scripts = document.querySelectorAll("script[data-src]");
 		var styles = document.querySelectorAll("style[data-href]");

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -11447,17 +11447,6 @@ Q.ServiceWorker = {
 			return callback(true);
 		}
 		Q.ServiceWorker.started = true;
-		// Every path below MUST end in onActive firing (with a worker, or
-		// with false like the not-supported branch above). Q.init pushes a
-		// "serviceWorker" readiness check whenever started is true, and that
-		// check is filled ONLY from onActive -- so an error path that forgets
-		// to fire it leaves Q.ready() permanently un-called: no page
-		// handlers, no hashchange/popstate/resize listeners, and every
-		// Q.page('') feature dead until the first Q.loadUrl navigation.
-		// Registration failures are an everyday occurrence, not a corner
-		// case: Firefox private windows refuse service workers, and some
-		// embedded/automation browser profiles block installation while
-		// fetch() of the same script succeeds.
 		function _failed(error) {
 			console.warn("Q.ServiceWorker.start error", error);
 			Q.handle(callback, Q.ServiceWorker, [false]);


### PR DESCRIPTION
## The bug

`Q.init` pushes a `"serviceWorker"` readiness check whenever `Q.ServiceWorker.started` is true — and `started` is set optimistically, before registration is known to have succeeded. That check is satisfied **only** by `Q.ServiceWorker.onActive` firing. The failure paths in `start()` never fire it:

- `register()` rejections call `callback(error)` and warn, and stop there
- the outer `getRegistration()` promise chain has no `.catch` at all
- a registration that comes back with no `active`/`waiting`/`installing` worker fires nothing

Any of those leaves `Q.ready()` permanently un-called. The consequences are broad and confusing: `Q.Page.onActivate('')` never fires, the `hashchange`/`popstate`/`resize`/`scroll` listeners never attach, and every `Q.page()` handler in every plugin is dead — until the first `Q.loadUrl` navigation incidentally heals the page. From the outside it looks like "event cards aren't clickable on a fresh load, but work after you navigate once."

Registration failures are ordinary, not exotic: Firefox private windows refuse service workers outright, and some embedded / automation browser profiles block installation while a plain `fetch()` of the same script succeeds. The not-supported branch at the top of `start()` already handles its case correctly by firing `onActive(false)`; the failure paths just don't.

A second, smaller consequence: `_startCachingWithServiceWorker`'s callback treated `start()`'s failure argument as a worker, which is the source of the recurring uncaught `worker.postMessage is not a function` rejection.

## The change

- A shared `_failed(error)` that warns, calls the callback with `false`, and fires `onActive(false)` — the same contract the not-supported branch already has. Both promise chains `.catch(_failed)`, and the no-worker case calls it explicitly.
- `_startCachingWithServiceWorker` returns early when it is handed a falsy worker.

## Verification

On a live page in a browser profile where registration reliably fails, with only this file changed between runs:

- **before:** `Q.Page.onActivate('').occurred` still `false` 20 seconds after a full load; event cards inert; first click works only after a navigation
- **after:** the ready callback completes, page handlers run, and a card click opens the event on the very first load with zero navigations

The patch is a port onto current `main` of a change verified on a slightly older `Q.js`; the touched region is unchanged apart from the cookie-jar listener that now follows it, and the file passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
