### PR TITLE
Q_Session: verify a session id's signature against the prefix it is presented under

### DIFF
--- a/platform/classes/Q/Session.php
+++ b/platform/classes/Q/Session.php
@@ -1304,17 +1304,24 @@ class Q_Session
 			$sig = Q_Utils::signature($prefix . $id, "$secret");
 			$id .= substr($sig, 0, 32);
 		}
-		return Q_Utils::hexToBase64($id);
+		// The prefix is part of what was signed, so it has to travel with the
+		// id: prefixSaysInternal() / prefixSaysAuthenticated() and Q_Valid
+		// read it from the id string. Without it, no session this server
+		// issues ever reads as internal or authenticated -- while any id a
+		// client re-labels does (see decodeId).
+		return $prefix . Q_Utils::hexToBase64($id);
 	}
 	
 	/**
-	 * @param string $id
+	 * @param string $id The id with its prefix already stripped
+	 * @param string [$prefix=''] The prefix it was presented under, or '' for none.
+	 *   The signature must have been made over exactly this prefix.
 	 *
 	 * @return array of (boolean $validId, string $firstPart, string $secondPart)
 	 * @throws Q_Exception
 	 * @throws TypeError
 	*/
-	protected static function decodeId($id)
+	protected static function decodeId($id, $prefix = '')
 	{
 		$result = Q_Utils::base64ToHex($id);
 		$a = substr($result, 0, 32);
@@ -1324,26 +1331,27 @@ class Q_Session
 		if (!isset($secret)) {
 			return array(true, $a, $b);
 		}
-		$expectedSigs = array(
-			substr(Q_Utils::signature($a, $secret), 0, 32)
-		);
-		foreach (Q_Config::get('Q', 'session', 'id', 'prefixes', array()) as $prefix) {
-			$expectedSigs[] = substr(Q_Utils::signature($prefix . $a, $secret), 0, 32);
-		}
-		foreach ($expectedSigs as $expected) {
-			if (Q_Utils::hashEquals($b, $expected)) {
-				return array(true, $a, $b);
-			}
-		}
-		return array(false, $a, $b);
+		// generateId() signs $prefix . $id, so a valid id carries the
+		// signature for ONE prefix -- the one it was issued under. Verify
+		// against that prefix and no other. Accepting a match under any
+		// configured prefix (or the bare id) meant the label was never
+		// actually checked: a client could take its own "sessionId_..."
+		// and present it as "sessionId_internal_...", isValidId() agreed,
+		// prefixSaysInternal() then returned true, and Q_Valid::nonce()
+		// short-circuited. Binding the label into what is verified makes
+		// re-labelling change the required signature, which the client
+		// cannot produce without the secret.
+		$expected = substr(Q_Utils::signature($prefix . $a, $secret), 0, 32);
+		return array(Q_Utils::hashEquals($b, $expected), $a, $b);
 	}
 
 	/**
 	 * Verifies a session id, that it was correctly signed with "Q"/"external"/"secret"
 	 * so that the web server won't have to deal with session ids we haven't issued.
 	 * This verification can also be done at the edge (e.g. CDN) without bothering our network.
-	 * Now this function strips prefixes separated by "_" or specified in Q/session/id/prefix config,
-	 * for example for a session ID like "sessionId_authenticated_abc123" it can strip "sessionId_authenticated_"
+	 * The id may carry one of the prefixes configured in Q/session/id/prefixes,
+	 * e.g. "sessionId_authenticated_abc123"; that prefix is stripped, and the
+	 * signature is then required to match that exact prefix.
 	 * @param {string} $id
 	 * @return {boolean}
 	 */
@@ -1352,19 +1360,25 @@ class Q_Session
 		if (!$id) {
 			return false;
 		}
-		$parts = explode('_', $id);
-		if (count($parts) > 1) {
-			$id = end($parts);
-		} else {
-			$prefixes = Q_Config::get('Q', 'session', 'id', 'prefixes', array());
-			foreach ($prefixes as $prefix) {
-				if (Q::startsWith($id, $prefix)) {
-					$id = substr($id, strlen($prefix));
-					break;
-				}
+		// Strip the longest CONFIGURED prefix and remember which one it was, so
+		// decodeId() can require the signature to match that exact prefix.
+		// Splitting on "_" and taking the tail accepted ANY leading text as a
+		// label while verifying a label-independent signature -- which is what
+		// let a client re-label a validly-signed id under a privileged prefix.
+		// Longest match, so "sessionId_internal_" wins over "sessionId_".
+		$prefixes = Q_Config::get('Q', 'session', 'id', 'prefixes', array());
+		usort($prefixes, function ($x, $y) {
+			return strlen($y) - strlen($x);
+		});
+		$matched = '';
+		foreach ($prefixes as $prefix) {
+			if ($prefix !== '' and Q::startsWith($id, $prefix)) {
+				$matched = $prefix;
+				$id = substr($id, strlen($prefix));
+				break;
 			}
 		}
-		$results = self::decodeId($id);
+		$results = self::decodeId($id, $matched);
 		return $results[0];
 	}
 


### PR DESCRIPTION
## The bug

A session id's prefix (`sessionId_`, `sessionId_authenticated_`, `sessionId_internal_`) is what `prefixSaysInternal()` and `prefixSaysAuthenticated()` read, and `Q_Valid::nonce()` short-circuits to true when the prefix says internal. So the prefix is a privilege claim, and it has to be covered by the signature.

Since `06bd74a`, `generateId()` does sign `$prefix . $id`. But `decodeId()` (from `0d3bcbd`) accepts a signature that matches the bare id **or any configured prefix**:

```php
$expectedSigs = array(substr(Q_Utils::signature($a, $secret), 0, 32));
foreach (Q_Config::get('Q', 'session', 'id', 'prefixes', array()) as $prefix) {
    $expectedSigs[] = substr(Q_Utils::signature($prefix . $a, $secret), 0, 32);
}
```

and `isValidId()` strips whatever label the client put in front (`explode('_')`, take the tail) without ever checking it. Between the two, the label is never verified:

1. A client takes its own valid session id — signed as `"sessionId_" . id` — and presents the cookie as `sessionId_internal_<same bytes>`.
2. `isValidId()` strips the label. `decodeId()` tries every prefix; `"sessionId_"` matches. Valid.
3. The session starts with that id. `Q_Session::id()` begins with `sessionId_internal_`, so `prefixSaysInternal()` is true, `Q_Valid::nonce()` returns true without checking, and the request runs as internal. `prefixSaysAuthenticated()` is forgeable the same way.

There is a second half. `06bd74a` also stopped *attaching* the prefix — `generateId()` returns `Q_Utils::hexToBase64($id)` with no `$prefix .` in front — but nothing else was changed to compensate: `prefixSays*()` and `calculateNonce()` still read the label from the id string. So on current `main`, **no session this server issues ever reads as internal or authenticated, while any id a client re-labels does.** The privileged label is only reachable by forging it.

## Reproduction

A stub harness that loads the real `Q/Session.php`, issues one id per prefix type with a configured secret, then re-presents each id's signed bytes under every other label. Against unpatched `main`:

```
  ok   issued '' id validates as presented
  FAIL issued '' id carries its own prefix
  ok   issued 'authenticated' id validates as presented
  FAIL issued 'authenticated' id carries its own prefix
  ok   issued 'internal' id validates as presented
  FAIL issued 'internal' id carries its own prefix
  FAIL '' id presented as 'authenticated' is REJECTED
  FAIL '' id presented as 'internal' is REJECTED
  FAIL 'authenticated' id presented as '' is REJECTED
  FAIL 'authenticated' id presented as 'internal' is REJECTED
  FAIL 'internal' id presented as '' is REJECTED
  FAIL 'internal' id presented as 'authenticated' is REJECTED
```

All six re-labelings are accepted. The same fork was verified end to end against a running app before `06bd74a` (visible prefix, bare-signed id): a forged `sessionId_internal_` cookie round-tripped as an accepted internal session.

## The change

Verify the signature against the prefix the id was presented under, and only that prefix.

- `decodeId($id, $prefix)` computes one expected signature, `signature($prefix . $a)`, and compares against it. No bare-id fallback, no loop over other prefixes. Re-labelling now changes the required signature, which a client cannot produce without the secret.
- `isValidId()` strips the **longest configured** prefix (so `sessionId_internal_` wins over `sessionId_`), remembers which one it stripped, and passes it down. It no longer accepts arbitrary leading text as a label.
- `generateId()` attaches the prefix again — `return $prefix . Q_Utils::hexToBase64($id)` — so the label that `prefixSays*()` reads is the one that was signed.

With the patch, the same harness:

```
  ok   issued '' id validates as presented
  ok   issued '' id carries its own prefix
  ok   issued 'authenticated' id validates as presented
  ok   issued 'authenticated' id carries its own prefix
  ok   issued 'internal' id validates as presented
  ok   issued 'internal' id carries its own prefix
  ok   '' id presented as 'authenticated' is REJECTED
  ok   '' id presented as 'internal' is REJECTED
  ok   'authenticated' id presented as '' is REJECTED
  ok   'authenticated' id presented as 'internal' is REJECTED
  ok   'internal' id presented as '' is REJECTED
  ok   'internal' id presented as 'authenticated' is REJECTED
```

## Rollout cost, stated plainly

This changes what a valid id looks like, so **every session issued before deploy becomes invalid once** — users are logged out a single time and get a fresh session on their next request. Ids issued by current `main` carry no prefix and were signed for `"sessionId_" . id`; presented bare, they would need `signature("" . id)`, which they don't have. I don't think there is a way to keep them valid without also keeping the re-labelling hole, because "accept the old form" is exactly "accept a signature made for a different label." Worth deploying at a chosen moment rather than silently.

## If the intent of `06bd74a` was to keep the label out of the cookie

That is a coherent design too: leave the id unlabelled, have `decodeId()` report *which* prefix's signature matched, and have `prefixSays*()` consult that verified result instead of the id string. It is a somewhat larger change (the per-request verified prefix has to be cached somewhere `prefixSays*()` can reach). Happy to rework this PR that way if that is the direction you prefer — the important property either way is that the privilege claim is what gets verified. This PR takes the smaller path.

Out of scope here, but adjacent: `decodeId()` still returns "valid" for every id when no `Q/internal/secret` is configured. That is a separate PR, touching neighbouring lines; whichever merges second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
