### PR TITLE
Q_Session: always sign and verify session ids; never key the nonce with the app name

### DIFF
--- a/platform/classes/Q/Session.php
+++ b/platform/classes/Q/Session.php
@@ -1109,7 +1109,14 @@ class Q_Session
 		}
 		$secret = Q_Config::get('Q', 'internal', 'secret', null);
 		if (!isset($secret)) {
-			$secret = Q::app();
+			// This used to fall back to Q::app(). The app name is public -- it
+			// is in the URL, the page source and the config -- so every nonce
+			// was computable by anyone, which is the one property a nonce must
+			// not have. Derive the key from the same default secret that
+			// Q_Utils::signature() already falls back to, so an install
+			// without "Q"/"internal"/"secret" gets a machine-local key rather
+			// than a published one.
+			$secret = Q_Utils::signature('Q_Session::calculateNonce');
 		}
 		return $longestPrefix . hash_hmac('sha256', $id, $secret);
 	}
@@ -1291,19 +1298,24 @@ class Q_Session
 			? hash('sha256', $seed) // length 64
 			: Q_Utils::randomHexString(64);
 		$prefix = Q_Config::expect('Q', 'session', 'id', 'prefixes', $prefixType);
-		$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		if (isset($secret)) {
-			$id = substr($id, 0, 32);
-			$time = (string)time();
-			$len = strlen($time);
-			if ($len < 11) {
-				$time = '0' . $time;
-				++$len;
-			}
-			$id = $time . substr($id, $len);
-			$sig = Q_Utils::signature($prefix . $id, "$secret");
-			$id .= substr($sig, 0, 32);
+		// Always sign. This used to skip signing when "Q"/"internal"/"secret"
+		// was not configured, and decodeId() correspondingly accepted every
+		// id -- so on such an install a client could present
+		// "sessionId_internal_<anything>" and be believed. Q_Utils::signature()
+		// already resolves the secret consistently (the configured one, else
+		// the same local default it uses for internal request signing), so
+		// there is no configuration in which an unsigned id is necessary.
+		// With the secret configured, the ids issued here are unchanged.
+		$id = substr($id, 0, 32);
+		$time = (string)time();
+		$len = strlen($time);
+		if ($len < 11) {
+			$time = '0' . $time;
+			++$len;
 		}
+		$id = $time . substr($id, $len);
+		$sig = Q_Utils::signature($prefix . $id);
+		$id .= substr($sig, 0, 32);
 		return Q_Utils::hexToBase64($id);
 	}
 	
@@ -1320,15 +1332,17 @@ class Q_Session
 		$a = substr($result, 0, 32);
 		$b = substr($result, 32, 32);
 		$b = $b ? $b : ''; // for older PHP
-		$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		if (!isset($secret)) {
-			return array(true, $a, $b);
-		}
+		// Always verify. Returning "valid" for every id when no secret was
+		// configured made the whole scheme rest on a config key nothing
+		// checked, and the failure was silent: an app whose secret was never
+		// set came up green and served traffic while trusting its callers.
+		// Q_Utils::signature() resolves the secret exactly as generateId()
+		// does, so ids this server issued still verify.
 		$expectedSigs = array(
-			substr(Q_Utils::signature($a, $secret), 0, 32)
+			substr(Q_Utils::signature($a), 0, 32)
 		);
 		foreach (Q_Config::get('Q', 'session', 'id', 'prefixes', array()) as $prefix) {
-			$expectedSigs[] = substr(Q_Utils::signature($prefix . $a, $secret), 0, 32);
+			$expectedSigs[] = substr(Q_Utils::signature($prefix . $a), 0, 32);
 		}
 		foreach ($expectedSigs as $expected) {
 			if (Q_Utils::hashEquals($b, $expected)) {


### PR DESCRIPTION
## The bug

When `"Q"/"internal"/"secret"` is not configured, session ids are neither signed nor verified:

- `generateId()` skips the signing block entirely (`if (isset($secret)) { ... }`) and issues a bare random id.
- `decodeId()` returns `array(true, $a, $b)` — valid — for **every** id.

`isValidId()` is what stands behind `prefixSaysInternal()` and `prefixSaysAuthenticated()`, so on such an install a client can present `sessionId_internal_<anything>` and be believed: `Q_Valid::nonce()` short-circuits, and the request runs as internal. The security of the whole scheme rests on a config key that nothing checks, and the failure is silent — an app whose secret was never set comes up green and serves traffic while trusting its callers.

This is inconsistent with the rest of the platform's own model. `Q_Utils::signature()` and `Q_Utils::sign()` already handle a missing secret by falling back to `generateLocalSecret()`, so internal *request* signing always happens. Session ids are the one place that gives up instead.

Reproduction, with a stub harness that loads the real `Q/Session.php` and no secret configured, against unpatched `main`:

```
  ok   still issues an id
  ok   own id validates
  FAIL made-up internal id is REJECTED      <- accepted
```

A related, smaller defect in the same file: `calculateNonce()` falls back to `Q::app()` as its HMAC key when no secret is configured. The app name is public — it is in the URL, the page source and the config — so every nonce is computable by anyone, which is the one property a nonce must not have.

## The change

Always sign, always verify, using the secret resolution the platform already has.

- `generateId()` always signs. It calls `Q_Utils::signature($prefix . $id)` with no explicit secret, which resolves to the configured secret if there is one and otherwise to the same local default that internal request signing uses. **With a configured secret, the issued ids are byte-for-byte unchanged**, so this causes no re-login on a properly configured install.
- `decodeId()` always verifies, with the same resolution. Ids this server issued still validate; made-up ones don't.
- `calculateNonce()` derives its fallback key from that same default secret (`Q_Utils::signature('Q_Session::calculateNonce')`) instead of the app name. Only affects installs with no configured secret, where outstanding nonces change once.

After the patch, same harness, no secret configured:

```
  ok   still issues an id
  ok   own id validates
  ok   made-up internal id is REJECTED
```

and with a secret configured every issued id validates exactly as before.

## Why this shape rather than failing closed

Refusing to issue or accept any id without a configured secret is the other reasonable fix (it's what #40 proposes for request signing). This PR deliberately stays inside the existing model instead — the platform has decided that a missing secret means "use the local default," and session ids should follow that decision rather than be the one exception that fails open. If #40's direction is taken, the fallback branch here simply becomes the throw; the always-sign/always-verify structure is right under either policy.

This touches lines adjacent to a separate PR on `decodeId()` (prefix-bound verification). They are independent; whichever merges second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
