### PR TITLE
harden: fix security issue in Q.js

### DIFF
--- a/platform/classes/Q.js
+++ b/platform/classes/Q.js
@@ -2642,11 +2642,28 @@ Q.listen = function _Q_listen(options, callback) {
 
 	var _methodHandlers = {};
 
+	// Basic rate limiting for the IPC endpoint, to mitigate DoS
+	// in case auth is bypassed or legitimate traffic misbehaves.
+	var _ipcRateLimit = {};
+	var _ipcRateLimitWindowMs = Q.Config.get(['Q', 'node', 'ipcRateLimit', 'windowMs'], 1000);
+	var _ipcRateLimitMax = Q.Config.get(['Q', 'node', 'ipcRateLimit', 'max'], 100);
+
 	// IPC + dispatch middleware. Runs for all POSTs to /Q/node.
 	app.post('/Q/node', function Q_ipc_dispatch(req, res, next) {
 		var parsed = req.body;
 		if (!parsed || !parsed['Q/method'] || !req.internal || !req.validated) {
 			return next();
+		}
+
+		var _ipcKey = (req.socket && req.socket.remoteAddress) || 'unknown';
+		var _ipcNow = Date.now();
+		var _ipcEntry = _ipcRateLimit[_ipcKey];
+		if (!_ipcEntry || _ipcNow - _ipcEntry.start > _ipcRateLimitWindowMs) {
+			_ipcEntry = _ipcRateLimit[_ipcKey] = { start: _ipcNow, count: 0 };
+		}
+		if (++_ipcEntry.count > _ipcRateLimitMax) {
+			res.statusCode = 429;
+			return res.end('Too Many Requests');
 		}
 
 		// Extract framework-level IPC fields from the signed payload.


### PR DESCRIPTION
## Summary
Harden input handling in `platform/classes/Q.js` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `platform/classes/Q.js:2646` |
| **Assessment** | Defensive hardening |

**Description**: The POST /Q/node IPC endpoint lacks visible rate limiting controls. While HMAC-SHA1 authentication via isFromNode() provides protection, the absence of rate limiting creates a denial of service vector if authentication is bypassed or if legitimate but excessive requests exhaust resources.

## Changes
- `platform/classes/Q.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: Protected endpoints reject unauthenticated requests

<details>
<summary>Regression test</summary>

```javascript
const request = require('supertest');
const app = require('../../platform/classes/Q.js');

describe('Protected endpoints reject unauthenticated requests', () => {
  const payloads = [
    { name: 'missing auth', headers: {} },
    { name: 'malformed token', headers: { 'X-Node-Auth': 'invalid-token-format' } },
    { name: 'empty token', headers: { 'X-Node-Auth': '' } },
  ];

  test.each(payloads)('rejects request with $name', async (payload) => {
    const response = await request(app)
      .post('/Q/node')
      .set(payload.headers)
      .send({});

    expect([401, 403]).toContain(response.status);
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->
