### PR TITLE
Bump mysql2 to ^3.23.1 and nodemailer to ^9.0.1 (8 advisories)

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -23,8 +23,8 @@
 		"html-entities": "^1.2.1",
 		"moment-timezone": "0.5.x",
 		"mysql": "2.16.x",
-		"mysql2": "3.0.0",
-		"nodemailer": "^6.9.13",
+		"mysql2": "^3.23.1",
+		"nodemailer": "^9.0.1",
 		"nodemailer-smtp-transport": "^2.4.2",
 		"request": "2.x.x",
 		"socket.io": "^4.7.5"


### PR DESCRIPTION
Eight published advisories affect the versions `platform/package.json` currently
resolves to — mysql2 `3.0.0` (an exact pin) and nodemailer `6.10.1`.

## mysql2 `3.0.0` → `^3.23.1`

| Advisory | Fixed in | Summary |
|---|---|---|
| [GHSA-3f6p-5ww8-9rcr](https://github.com/advisories/GHSA-3f6p-5ww8-9rcr) (High) | 3.22.0 | Auth plugin downgrade to `mysql_clear_password` leaks plaintext credentials |
| [GHSA-rgwj-5xj2-c3m3](https://github.com/advisories/GHSA-rgwj-5xj2-c3m3) (Moderate) | 3.23.1 | Unbounded zlib inflate in the compressed MySQL protocol handler (decompression bomb) |

The exact `3.0.0` pin is the bigger issue than either CVE: it is a January-2023
release, now 24 minors behind, so no upstream fix of any kind could ever reach a
Qbix install. The 3.x line declares no breaking changes.

The decompression bomb specifically needs `compress: true`, which
`Db/Mysql.js:mysqlConnection()` never sets, so it is not reachable through Qbix's
own call site today.

## nodemailer `^6.9.13` → `^9.0.1`

Six advisories, fixed across 8.0.4 / 8.0.5 / 8.0.8 / 8.0.9 (×2) / 9.0.1 — so
9.0.1 is the first release that clears all six at once.

| Advisory | CVE | Fixed in |
|---|---|---|
| [GHSA-268h-hp4c-crq3](https://github.com/advisories/GHSA-268h-hp4c-crq3) — CRLF injection via `List-*` header comments | CVE-2026-82661 | 8.0.9 |
| [GHSA-c7w3-x93f-qmm8](https://github.com/advisories/GHSA-c7w3-x93f-qmm8) — SMTP command injection via `envelope.size` | CVE-2026-82854 | 8.0.4 |
| [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) — `raw` bypasses `disableFileAccess`/`disableUrlAccess` (arbitrary file read, SSRF) | CVE-2026-82659 | 9.0.1 |
| [GHSA-r7g4-qg5f-qqm2](https://github.com/advisories/GHSA-r7g4-qg5f-qqm2) — OAuth2 token fetch skips TLS validation | CVE-2026-82662 | 8.0.8 |
| [GHSA-vvjj-xcjg-gr5g](https://github.com/advisories/GHSA-vvjj-xcjg-gr5g) — CRLF in transport `name` (EHLO/HELO) | CVE-2026-82853 | 8.0.5 |
| [GHSA-wqvq-jvpq-h66f](https://github.com/advisories/GHSA-wqvq-jvpq-h66f) — `jsonTransport` bypasses file/URL access flags | CVE-2026-82660 | 8.0.9 |

None of these is exploitable through Qbix's current call site —
`Users/classes/Users/Email.js` builds `{from, to, subject, html|text}` with no
`headers`, `envelope`, `raw`, `jsonTransport` or OAuth2. But `sendMessage()` is a
generic helper that forwards caller-supplied `options`, so this is one future
caller away from being live.

**A companion PR is filed on `Qbix/Users`** for the same bump in
`plugins/Users/package.json`. That one is the load-bearing manifest: because
`Email.js` lives inside the plugin, Node resolves its `require('nodemailer')`
against `plugins/Users/node_modules` first. Bumping only this root manifest would
not change the mailer that actually runs — both are needed, which is why they are
bumped in step.

## Breaking changes across the three nodemailer majors — none applicable

- **7.0.0** — replaced the AWS SES SDK v2/v3 transport with SESv2 and dropped SES
  rate limiting. There is no SES transport anywhere in the tree.
- **8.0.0** — error code `NoAuth` renamed to `ENOAUTH`. Nothing reads nodemailer
  error codes; `Email.js` passes `err` straight to its callback.
- **9.0.0** — HTTPS requests made while fetching remote content (attachment
  `href`/`path` URLs, OAuth2 token endpoints, proxy CONNECT) now validate TLS
  certificates by default. Qbix fetches no remote content, uses no OAuth2 and no
  proxy, so this is strictly an improvement.

Capped below `10.0.0` deliberately: that is a brand-new TypeScript rewrite with
ESM+CJS builds and a Node ≥ 20 floor, and taking it in the same change as a
security bump would confuse two unrelated risks.

## Verified against the resolved versions (nodemailer 9.1.1, mysql2 3.24.3)

1. **The deprecated transport shims still work.** This was the real risk in the
   bump. `Email.js` calls `mailer.createTransport(sendmailTransport())` and
   `mailer.createTransport(smtpTransport(host))` using
   `nodemailer-sendmail-transport@1.0.2` and `nodemailer-smtp-transport@2.7.4` —
   2016-era packages that predate nodemailer's built-in transports by three
   majors. Reproduced that exact construction against nodemailer 9.1.1 with a
   throwaway in-process SMTP sink: both transports constructed (`Sendmail 1.0.2`,
   `SMTP 2.7.4[client:2.12.0]`), and a full `sendMail` through the SMTP shim
   completed — `250 OK queued`, both comma-separated recipients in `accepted`,
   EHLO and two `RCPT TO`s observed on the wire.

2. **`Db/Mysql.js`'s reach into mysql2 internals survives, for a non-obvious
   reason.** That code patches `lib/constants/encoding_charset` to alias
   `utf8mb3` → `utf8mb4`. mysql2 3.24 added an `exports` map to its
   `package.json`, so the bare specifier
   `require('mysql2/lib/constants/encoding_charset')` now throws
   `ERR_PACKAGE_PATH_NOT_EXPORTED`. Qbix resolves the package directory through
   `Q.absoluteModulePath()` first and requires an **absolute** path, which
   bypasses the exports map — so it keeps working. Confirmed both halves against
   3.24.3.

   Worth knowing independently of this PR: that require sits inside a bare
   `catch (e) {}`, so rewriting it as a bare specifier would silently degrade
   utf8mb3 handling with no error surfaced anywhere.

3. **`createConnection` accepts the same option object** — `charsetNumber: 224`
   and `multipleStatements: true`, the latter required because `reallyConnect()`
   issues `SET NAMES utf8mb4; SET time_zone = ...` as a single multi-statement
   query. Also confirmed `connection.config.compress === false` by default with
   that exact object.

Found via a weekly OSV sweep over pinned dependencies; happy to adjust the ranges
if you would rather pin exactly or take a different ceiling.
