### PR TITLE
Blur the dialog backdrop on the mask, and size masks to the viewport

### DIFF
--- a/platform/plugins/Q/web/css/Q.css
+++ b/platform/plugins/Q/web/css/Q.css
@@ -238,6 +238,17 @@ body { position: relative; margin: 0; }
 .Q_notice_mask,
 .Q_screen_mask,
 .Q_dialog_mask { background-color: rgba(0, 0, 0, 0.2); }
+/* The blur behind a dialog lives on the mask, not on the content. Filtering
+   #page / #dashboard_slot instead blurred only as much of the screen as those
+   elements covered, and removing the filter on close forced a visible repaint
+   of a fixed header (Q_fixed_top) — cards appeared to lose their borders and
+   shadows for a frame. backdrop-filter blurs whatever is painted below the
+   mask, so it follows the mask's own (viewport-sized) box and disappears with
+   it. */
+.Q_dialog_mask {
+	backdrop-filter: blur(5px);
+	-webkit-backdrop-filter: blur(5px);
+}
 .Q_load_mask { background-color: rgba(0, 0, 0, 0.3); background-image: radial-gradient(circle at center 200px,hsla(0,0%,100%,.1),#000); background-attachment: fixed; }
 .Q_click_mask { background: transparent; }
 .Q_button.Q_load_cancel_button { position: absolute; left: 50vw; top: 50vh; margin-left: -25px; margin-top: -50px; box-shadow: 0 0 25px 5px rgba(255, 255, 255, 0.5); }
@@ -988,10 +999,8 @@ input[type=password] {
     -moz-appearance: none;
 }
 
-html.Q_dialog_shown #page,
-html.Q_dialog_shown #dashboard_slot {
-	filter:blur(5px);
-}
+/* No `filter: blur()` on #page / #dashboard_slot while a dialog is open —
+   see .Q_dialog_mask above for where the blur lives now and why. */
 
 .Q_notMobile #dashboard_slot>* { color: var(--dashboard-main-color); font-size: 20px; }
 .Q_mobile #dashboard_slot>* { color: var(--dashboard-mobile-color, var(--dashboard-main-color)); }

--- a/platform/plugins/Q/web/js/Q.js
+++ b/platform/plugins/Q/web/js/Q.js
@@ -17531,12 +17531,29 @@ Q.Masks = {
 			}
 			var mask = Q.Masks.collection[k];
 			if (!mask.counter) continue;
-			var html = document.documentElement;
 			var bodyRect = document.body.getBoundingClientRect();
 			var scrollLeft = Q.Visual.scrollLeft() - bodyRect.left;
 			var scrollTop = Q.Visual.scrollTop() - bodyRect.top;
 			var ms = mask.element.style;
-			var rect = (mask.shouldCover || html).getBoundingClientRect();
+			if (!mask.shouldCover) {
+				// A mask with no shouldCover is meant to cover *everything*.
+				// Sizing it from <html>'s bounding rect only covers the
+				// viewport when <html> happens to fill it: any layout that
+				// constrains or centers the html box (or a horizontally
+				// scrolled page) leaves part of the screen unmasked, and
+				// scrolling moves the mask off the visible area. Pin it to the
+				// viewport instead — position:fixed also means Q.onLayout no
+				// longer has to chase scroll offsets for these masks.
+				var vw = window.innerWidth;
+				var vh = window.innerHeight;
+				mask.rect = { 'left': 0, 'top': 0, 'right': vw, 'bottom': vh };
+				ms.position = 'fixed';
+				ms.left = ms.top = '0px';
+				ms.width = vw + 'px';
+				ms.height = ms['line-height'] = vh + 'px';
+				continue;
+			}
+			var rect = mask.shouldCover.getBoundingClientRect();
 			mask.rect = {
 				'left': rect.left,
 				'right': rect.right,


### PR DESCRIPTION
Two dialog-backdrop defects with one cause.

### 1. The backdrop only covers part of the screen

`Q.Masks.update()` sizes every mask that has no `shouldCover` from `document.documentElement.getBoundingClientRect()`. That equals the viewport only when `<html>` happens to fill it — constrain or centre the html box and the mask shrinks with it, leaving the rest of the screen unmasked and unblurred behind an open dialog. Measured on an 1800x1000 viewport with the html box at 720px: `.Q_dialog_mask` came out **720px wide at x=540**. Those masks are also `position: absolute`, so they slide out of view when the document scrolls.

A mask with no `shouldCover` means "cover everything", so this pins it to the viewport with `position: fixed` at `0,0` and `innerWidth x innerHeight`. That also means the `Q.onLayout` call no longer has to chase scroll offsets for these masks. Masks that *do* name a `shouldCover` element go down the unchanged path.

### 2. The close flash

`html.Q_dialog_shown #page, #dashboard_slot { filter: blur(5px) }` puts the blur on the content. Dropping a `filter` from a `position: fixed` header forces a repaint of it, which reads as cards briefly losing their borders, shadows and padding on every dialog close. Sampling computed styles on the cards each animation frame across a real close shows the cards never change — the only change is `#page` going `blur(5px)` -> `none` in one frame.

So the blur moves to a `backdrop-filter` on `.Q_dialog_mask`. It blurs whatever is painted below the mask (mask `z-index: 1000`, above `#page` and `#dashboard_slot`; the dialog is `9001`, above the mask), it follows the mask's own now-viewport-sized box, and it disappears with the mask instead of leaving a filter behind to remove.

### Verification

Against a running Communities-based app, at 1800x1000 and 390x844, logged out and logged in:

| | before | after |
|---|---|---|
| mask box, html box constrained to 720px | `x=540 w=720` (`position: absolute`) | `x=0 w=1800` (`position: fixed`) |
| `.Q_dialog_mask` backdrop-filter | `none` | `blur(5px)` |
| computed filter on `#page` / `#dashboard_slot` while open | `blur(5px)` | `none` |
| same, sampled each frame across a close | `blur(5px)` -> `none` (one-frame transition) | `none` throughout |

No JS errors in either configuration. Companion PR on Qbix/Communities removes the same rule under `html.Communities_dialog`.
