### PR TITLE
Db: quote database and table identifiers in generated SQL

### DIFF
--- a/platform/classes/Db/Mysql.php
+++ b/platform/classes/Db/Mysql.php
@@ -345,7 +345,7 @@ class Db_Mysql implements Db_Interface
 		}
 		
 		$clauses = array(
-			'INTO' => "$table_into ($columnsString)",
+			'INTO' => Db_Query_Mysql::quotedTable($table_into)." ($columnsString)",
 			'VALUES' => $valuesString
 		);
 		
@@ -814,7 +814,7 @@ class Db_Mysql implements Db_Interface
 		if (empty($table))
 			throw new Exception("table not specified in call to 'update'.");
 		
-		$clauses = array('UPDATE' => "$table");
+		$clauses = array('UPDATE' => (string)Db_Query_Mysql::quotedTable($table));
 		return new Db_Query_Mysql($this, Db_Query::TYPE_UPDATE, $clauses, array(), $table);
 	}
 
@@ -835,9 +835,10 @@ class Db_Mysql implements Db_Interface
 		}
 
 		if (isset($table_using))
-			$clauses = array('FROM' => "$table_from USING $table_using");
+			$clauses = array('FROM' => Db_Query_Mysql::quotedTable($table_from)
+				." USING ".Db_Query_Mysql::quotedTable($table_using));
 		else
-			$clauses = array('FROM' => "$table_from");
+			$clauses = array('FROM' => (string)Db_Query_Mysql::quotedTable($table_from));
 		return new Db_Query_Mysql($this, Db_Query::TYPE_DELETE, $clauses, array(), $table_from);
 	}
 
@@ -1476,7 +1477,7 @@ class Db_Mysql implements Db_Interface
 	}
 
 	public function _introspectColumns($table_name) {
-		return $this->rawQuery("SHOW FULL COLUMNS FROM $table_name")->execute()->fetchAll(PDO::FETCH_ASSOC);
+		return $this->rawQuery("SHOW FULL COLUMNS FROM ".Db_Query_Mysql::quotedIfBare($table_name))->execute()->fetchAll(PDO::FETCH_ASSOC);
 	}
 
 	public function _introspectTableComment($table_name) {
@@ -1487,7 +1488,7 @@ class Db_Mysql implements Db_Interface
 
 	public function _introspectTableIndexes($table_name)
 	{
-		$rows = $this->rawQuery("SHOW INDEX FROM $table_name")
+		$rows = $this->rawQuery("SHOW INDEX FROM ".Db_Query_Mysql::quotedIfBare($table_name))
 			->execute()
 			->fetchAll(PDO::FETCH_ASSOC);
 

--- a/platform/classes/Db/Query.php
+++ b/platform/classes/Db/Query.php
@@ -878,9 +878,7 @@ abstract class Db_Query extends Db_Expression
 				);
 			}
 		}
-		foreach ($this->replacements as $k => $v) {
-			$repres = str_replace($k, $v, $repres);
-		}
+		$repres = $this->applyReplacements($repres);
 		if (isset($callback)) {
 			$args = array($repres);
 			Q::call($callback, $args);
@@ -1385,6 +1383,7 @@ abstract class Db_Query extends Db_Expression
 							$this->parameters, $table->parameters
 						);
 					} else {
+						$table = static::quotedTable($table);
 						$table_string = is_int($alias) ? "$table" : "$table $as $alias";
 					}
 					if ($repeat and in_array($table_string, $prev_tables_list)) {
@@ -1404,6 +1403,7 @@ abstract class Db_Query extends Db_Expression
 			if (! is_string($tables)) {
 				throw new Exception("The tables to select from need to be specified correctly.", -1);
 			}
+			$tables = static::quotedTable($tables);
 
 			if (empty($this->clauses['FROM'])) {
 				$this->clauses['FROM'] = $tables;
@@ -1474,6 +1474,7 @@ abstract class Db_Query extends Db_Expression
 			throw new Exception("The JOIN condition needs to be specified correctly.", -1);
 		}
 
+		$table = static::quotedTable($table);
 		$join = "$join_type JOIN $table ON ($condition)";
 
 		if (empty($this->clauses['JOIN'])) {
@@ -2513,6 +2514,102 @@ abstract class Db_Query extends Db_Expression
 
 	static function quoted($identifier) {
 		return '"' . str_replace('"', '""', $identifier) . '"'; // ANSI default, override per adapter
+	}
+
+	/**
+	 * Quotes $expression if it is a bare identifier, and otherwise returns it
+	 * untouched.
+	 * @method quotedIfBare
+	 * @static
+	 * @param {string} $expression
+	 * @return {string}
+	 */
+	static function quotedIfBare($expression)
+	{
+		return preg_match('/^[A-Za-z0-9_$-]+$/', $expression)
+			? static::quoted($expression)
+			: $expression;
+	}
+
+	/**
+	 * Quotes a table reference of the form "name", "dbname.name", or either of
+	 * those followed by an alias, and returns anything else untouched.
+	 *
+	 * Generated Base_* classes build their table reference by concatenation --
+	 * $db->dbName().'.'.$table_name.$alias -- so a database name that is not a
+	 * bare identifier (a hyphen, a reserved word) produced invalid SQL:
+	 *
+	 *     SELECT identifier, userId FROM my-app.users_identify WHERE ...
+	 *
+	 * Only the leading run of bare, dot-separated identifiers is quoted, and
+	 * only when the whole expression is one of those optionally followed by
+	 * whitespace and an alias. A subquery, a comma-separated list, an
+	 * already-quoted name, or anything else carrying punctuation is returned
+	 * exactly as it came in -- including the "{{dbname}}.{{prefix}}x" token
+	 * form, which applyReplacements() quotes instead.
+	 * @method quotedTable
+	 * @static
+	 * @param {string|Db_Expression} $expression
+	 * @return {string|Db_Expression}
+	 */
+	static function quotedTable($expression)
+	{
+		if (!is_string($expression)) {
+			return $expression;
+		}
+		if (!preg_match(
+			'/^([A-Za-z0-9_$-]+(?:\.[A-Za-z0-9_$-]+)*)(\s[\s\S]*)?$/',
+			$expression, $matches
+		)) {
+			return $expression;
+		}
+		$parts = explode('.', $matches[1]);
+		foreach ($parts as $i => $part) {
+			$parts[$i] = static::quoted($part);
+		}
+		return implode('.', $parts)
+			. (isset($matches[2]) ? $matches[2] : '');
+	}
+
+	/**
+	 * Substitutes {{dbname}}, {{prefix}} and the other replacements into
+	 * generated SQL. A table reference of the shape "{{dbname}}.{{prefix}}base"
+	 * is two bare identifiers, so both halves are quoted here.
+	 *
+	 * The values in $this->replacements are deliberately left unquoted: the
+	 * sharding code substitutes them into a table name and compares the result
+	 * against the dbTable it sends to node.js.
+	 * @method applyReplacements
+	 * @protected
+	 * @param {string} $sql
+	 * @return {string}
+	 */
+	protected function applyReplacements($sql)
+	{
+		if (isset($this->replacements['{{dbname}}'])) {
+			$dbname = $this->replacements['{{dbname}}'];
+			if (isset($this->replacements['{{prefix}}'])) {
+				$prefix = $this->replacements['{{prefix}}'];
+				$class = get_called_class();
+				$sql = preg_replace_callback(
+					'/\{\{dbname\}\}\.\{\{prefix\}\}([A-Za-z0-9_$]+)/',
+					function ($m) use ($dbname, $prefix, $class) {
+						return call_user_func(array($class, 'quotedIfBare'), $dbname)
+							. '.' . call_user_func(
+								array($class, 'quotedIfBare'), $prefix.$m[1]
+							);
+					},
+					$sql
+				);
+			}
+			$sql = str_replace(
+				'{{dbname}}.', static::quotedIfBare($dbname).'.', $sql
+			);
+		}
+		foreach ($this->replacements as $k => $v) {
+			$sql = str_replace($k, $v, $sql);
+		}
+		return $sql;
 	}
 
 	/**

--- a/platform/classes/Db/Sqlite.php
+++ b/platform/classes/Db/Sqlite.php
@@ -298,7 +298,7 @@ class Db_Sqlite implements Db_Interface
 			$valuesString = '';
 		}
 		$clauses = array(
-			'INTO' => "$table_into ($columnsString)",
+			'INTO' => Db_Query_Sqlite::quotedTable($table_into)." ($columnsString)",
 			'VALUES' => $valuesString
 		);
 		return new $queryClass($this, Db_Query::TYPE_INSERT, $clauses, $fields, $table_into);
@@ -313,7 +313,7 @@ class Db_Sqlite implements Db_Interface
 		if (empty($table))
 			throw new Exception("table not specified in call to 'update'.");
 		$queryClass = Db_Query::adapterClass($this);
-		$clauses = array('UPDATE' => "$table");
+		$clauses = array('UPDATE' => (string)Db_Query_Sqlite::quotedTable($table));
 		return new $queryClass($this, Db_Query::TYPE_UPDATE, $clauses, array(), $table);
 	}
 
@@ -330,9 +330,10 @@ class Db_Sqlite implements Db_Interface
 		}
 		$queryClass = Db_Query::adapterClass($this);
 		if (isset($table_using))
-			$clauses = array('FROM' => "$table_from USING $table_using");
+			$clauses = array('FROM' => Db_Query_Sqlite::quotedTable($table_from)
+				." USING ".Db_Query_Sqlite::quotedTable($table_using));
 		else
-			$clauses = array('FROM' => "$table_from");
+			$clauses = array('FROM' => (string)Db_Query_Sqlite::quotedTable($table_from));
 		return new $queryClass($this, Db_Query::TYPE_DELETE, $clauses, array(), $table_from);
 	}
 


### PR DESCRIPTION
A database name that is not a bare SQL identifier — one containing a hyphen, or a reserved word — makes **every** query fail, because the database and table names are interpolated into the SQL by plain string concatenation.

Reproduced by creating an application whose database name has a hyphen and running `install.php`:

```
Installing plugin 'Users' into '/var/www/app'
Processing PHP file: 0.8.3-Users.mysql.php
You have an error in your SQL syntax; … near '-app.users_identify

Query was: SELECT identifier,insertedTime,updatedTime,state,userId
FROM my-app.users_identify
WHERE `identifier` = 'username_hashed:…'  LIMIT 1
```

That is the *first* query `install.php` runs (`Users/scripts/Users/0.8.3-Users.mysql.php` → `Db_Row->save()` → `Users_User->beforeSave()` → `Db_Row->retrieve()` → `fetchDbRows('Users_Identify')`), so such an application cannot be installed at all.

### The part that is easy to get wrong

There are **two** shapes to quote, because a generated `Base_*::table()` emits two:

```php
if (Q_Config::get('Db','connections','Users','indexes','User', false)) {
    return new Db_Expression('{{dbname}}.'.'{{prefix}}'.'user');   // sharded
} else {
    $db = Db::connect('Users');
    return $db->dbName().'.'.$prefix.'user'.$alias;                // ordinary
}
```

The token form is the **sharding** branch. Without sharding indexes declared for that table the `else` branch runs, and the table reference arrives at the query builder **already resolved** as the plain string `my-app.users_user` — it never passes through token substitution, so quoting `{{dbname}}` alone changes nothing on the path that actually breaks.

### The change

* `Db_Query::quotedTable()` quotes a bare table reference where `select()`, `join()`, `insert()`, `update()` and `delete()` place it into a clause. It rewrites **only** one or more dot-separated bare identifiers, optionally followed by whitespace and an alias. A subquery, a comma-separated list, an already-quoted name and the `{{...}}` token form are returned exactly as they came in, so aliased tables, `JOIN` expressions and hand-written SQL are unaffected.
* `Db_Query::applyReplacements()` quotes both halves of the token form as it substitutes, for the sharded branch.
* `Db_Query::quotedIfBare()` is the shared predicate. Both helpers go through `static::quoted()`, so each adapter keeps its own quoting style — backticks for MySQL, ANSI double quotes by default — and `Db_Sqlite` gets the same treatment as `Db_Mysql`.
* Also quotes `$table_name` in the two `SHOW` statements `Db_Mysql`'s model generator runs.

### One deliberate non-change

The values in `$this->replacements` stay **unquoted**. `Db_Utils`' sharding code substitutes them into a table name and compares the result against the `dbTable` it sends to node.js; quoting the stored value would break that comparison silently. The quoting happens on the emitted SQL instead.

### Testing

Downstream we run a full integration tier — schema install from the plugin `.mysql` scripts, then real `Db_Row->save()` / `retrieve()` / Streams avatar hooks against a throwaway MySQL — with the database named `ci-boot`. Before this change it reproduces the failure above; after it, green. The ordinary (non-hyphenated) path is unchanged and covered by the same tier plus a browser smoke stack that runs `install.php`.
