### PR TITLE
Q_Valid::signature(), Utils.validate(): fail closed when Q/internal/secret is not configured

### DIFF
--- a/platform/classes/Q/Utils.js
+++ b/platform/classes/Q/Utils.js
@@ -63,6 +63,28 @@ function generateLocalSecret() {
 		.digest('hex');
 }
 
+/**
+ * Returns the configured Q/internal/secret, or throws.
+ * Mirrors Q_Utils::requireInternalSecret() in PHP, including treating the empty
+ * string and the "TODO: ..." placeholder that local.sample ships as
+ * unconfigured -- that placeholder is published in every copy of this
+ * repository, so an install that keeps it holds a secret every attacker already
+ * has, and can therefore sign with it.
+ * @method requireInternalSecret
+ * @private
+ * @return {string}
+ */
+function requireInternalSecret() {
+	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
+	if (typeof secret === 'string') {
+		secret = secret.trim();
+		if (secret !== '' && secret.substr(0, 5) !== 'TODO:') {
+			return secret;
+		}
+	}
+	throw new Error('Q/internal/secret is not configured');
+}
+
 function ksort(obj) {
 	var i, sorted = {}, keys = Object.keys(obj);
 	keys.sort();
@@ -177,13 +199,19 @@ Utils.sign = function (data, fieldKeys) {
  * @method validate
  * @param {object} data the signed data to validate
  * @param {array} fieldKeys Optionally specify the array key path for the signature field
- * @return {boolean} Whether the signature is valid. Returns true if secret is empty.
+ * @return {boolean} Whether the signature is valid. Returns false (never true)
+ *  when "Q"/"internal"/"secret" is not configured: a validator must not read
+ *  "no key" as "valid". Producing a signature may still fall back to a
+ *  machine-local key (see Utils.signature); accepting one never does.
  */
 Utils.validate = function(data, fieldKeys) {
 	var temp = Q.copy(data, null, 100);
-	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
-	if (!secret) {
-		secret = generateLocalSecret();
+	var secret;
+	try {
+		secret = requireInternalSecret();
+	} catch (e) {
+		console.warn('Q.Utils.validate: rejecting, ' + e.message);
+		return false;
 	}
 	if (!fieldKeys || !fieldKeys.length) {
 		var sf = Q.Config.get(['Q', 'internal', 'sigField'], 'sig');

--- a/platform/classes/Q/Utils.php
+++ b/platform/classes/Q/Utils.php
@@ -387,6 +387,31 @@ class Q_Utils
 	}
 
 	/**
+	 * Returns the configured "Q"/"internal"/"secret", or throws.
+	 * The empty string and the "TODO: ..." placeholder that local.sample ships
+	 * count as unconfigured -- the placeholder is a fixed value published in
+	 * every copy of this repository, so an install that keeps it holds a secret
+	 * every attacker already has and can therefore sign with.
+	 * @method requireInternalSecret
+	 * @static
+	 * @return {string}
+	 * @throws {Q_Exception_MissingConfig}
+	 */
+	static function requireInternalSecret()
+	{
+		$secret = Q_Config::get('Q', 'internal', 'secret', null);
+		if (is_string($secret)) {
+			$secret = trim($secret);
+			if ($secret !== '' and !Q::startsWith($secret, 'TODO:')) {
+				return $secret;
+			}
+		}
+		throw new Q_Exception_MissingConfig(array(
+			'fieldpath' => 'Q/internal/secret'
+		));
+	}
+
+	/**
 	 * Generate a local secret that is stable but hard to guess from outside
 	 * @method generateLocalSecret
 	 * @static

--- a/platform/classes/Q/Valid.php
+++ b/platform/classes/Q/Valid.php
@@ -337,8 +337,10 @@ class Q_Valid
 	 * @param {array|string} [$fieldKeys] Path of the key under which signature is stored.
 	 *   You can pass a string here instead, which would be the actual signature to test.
 	 * @param {string} [$secret] A different secret to use for generating the signature
-	 * @return {boolean} Whether the phone number seems like it could be valid
+	 * @return {boolean} Whether the signature checked out
 	 * @throws {Q_Exception_FailedValidation}
+	 * @throws {Q_Exception_MissingConfig} if $throwIfInvalid and no $secret is
+	 *  passed and "Q"/"internal"/"secret" is not configured
 	 */
 	static function signature (
 		$throwIfInvalid = false, 
@@ -350,10 +352,22 @@ class Q_Valid
 			$data = $_REQUEST;
 		}
 		if (!isset($secret)) {
-			$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		}
-		if (!isset($secret)) {
-			return true;
+			// Fail CLOSED. This used to `return true` -- with no internal secret
+			// configured, EVERY payload validated, so an unsigned or forged
+			// request passed every gate built on this: handlers/Q/config/validate.php
+			// (which writes config onto the machine), Streams::invites(),
+			// Media/callCenter. A validator must never read "no key" as "valid".
+			// Producing a signature may still fall back to a machine-local key
+			// (see Q_Utils::signature()); accepting one never does.
+			try {
+				$secret = Q_Utils::requireInternalSecret();
+			} catch (Q_Exception_MissingConfig $e) {
+				if ($throwIfInvalid) {
+					Q_Response::code(403);
+					throw $e;
+				}
+				return false;
+			}
 		}
 		$invalid = true;
 		if (is_array($fieldKeys)) {


### PR DESCRIPTION
The accepting half of #40, split out as requested there. Producing a signature is untouched here — that policy is in a follow-up PR based on this one.

## The bug

`Q_Valid::signature()` returns `true` for every payload when no secret is available:

```php
if (!isset($secret)) {
    return true;
}
```

It is a validator, and it reads "no key" as "valid". Everything built on it is an internal gate: `handlers/Q/config/validate.php` is the check on `Q_Config_post()` before it dispatches to `Q_Config::setOnServer()` / `clearOnServer()` with a client-supplied `filename` and `data`; also `Streams::invites()` and `Media/callCenter`. On an install with no `Q/internal/secret`, that is an unsigned POST writing config files onto the machine, while the app looks healthy.

## The change

- `Q_Valid::signature()` fails closed. All three in-tree call sites pass `$throwIfInvalid = true`, so the rejection surfaces as the existing `Q_Response::code(403)`, with `Q_Exception_MissingConfig` naming the key at fault rather than blaming the caller for a local misconfiguration.
- `Q_Utils::requireInternalSecret()` is new and additive. It treats the empty string and the `TODO: CHANGE TO SOME RANDOM STRING, …` literal that `local.sample/app.json` ships as unconfigured — that literal is a fixed value published in every copy of this repository, so an install that keeps it holds a secret every attacker already has.
- `Utils.validate()` in `Q/Utils.js` had the same fallback, and its docblock advertised "Returns true if secret is empty". It now returns `false` with a console warning. `Utils.signature()` and `Utils.sign()` are untouched here.

Behaviour with a secret configured is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
