### PR TITLE
Q_Utils::sign() throws without Q/internal/secret; signature() keeps the local fallback; install.php checks the secret

### DIFF
--- a/platform/classes/Q/Plugin.php
+++ b/platform/classes/Q/Plugin.php
@@ -844,6 +844,20 @@ class Q_Plugin
 			Q_Bootstrap::checkRequirementsApp();
 		}
 
+		// A missing or placeholder Q/internal/secret is discovered here, where
+		// an operator can act on it, rather than by the first visitor after a
+		// deploy. Without it Q_Valid::signature() rejects every internal
+		// request and Q_Utils::sign() throws, by design.
+		try {
+			Q_Utils::requireInternalSecret();
+		} catch (Q_Exception_MissingConfig $e) {
+			throw new Exception(
+				'Q/internal/secret is not set, or is still the placeholder. '
+				. 'Set it to a long random string in '
+				. APP_LOCAL_DIR . DS . 'app.json under "Q" > "internal" > "secret".'
+			);
+		}
+
 		// Check access to $app_installed_file
 		if(file_exists($app_installed_file) && !is_writable($app_installed_file))
 			throw new Exception("Can not write to $app_installed_file");

--- a/platform/classes/Q/Utils.js
+++ b/platform/classes/Q/Utils.js
@@ -25,7 +25,13 @@ var Utils = {};
  * @private
  * @return {string}
  */
+var _localSecret = null;
 function generateLocalSecret() {
+	// Inputs are fixed for the life of the process; memoize so the
+	// per-request signature() calls don't re-read /etc/machine-id.
+	if (_localSecret) {
+		return _localSecret;
+	}
 	var os = require('os');
 	var child_process = require('child_process');
 
@@ -58,7 +64,7 @@ function generateLocalSecret() {
 		}
 	} catch (e) {}
 
-	return crypto.createHash('sha256')
+	return _localSecret = crypto.createHash('sha256')
 		.update(parts.join("\t"))
 		.digest('hex');
 }
@@ -156,6 +162,9 @@ function http_build_query (formdata, numeric_prefix, arg_separator) {
 Utils.signature = function (data, secret) {
 	secret = secret || Q.Config.get(['Q', 'internal', 'secret'], null);
 	if (!secret) {
+		// Producing a signature may degrade to a machine-local key: it lets
+		// nobody in. Accepting one never does (Utils.validate) and handing
+		// one out never does either (Utils.sign). Mirrors Q_Utils in PHP.
 		secret = generateLocalSecret();
 	}
 	if (typeof(data) !== 'string') {
@@ -170,12 +179,12 @@ Utils.signature = function (data, secret) {
  * @param {object} data The data to sign
  * @param {array} fieldKeys Optionally specify the array key path for the signature field
  * @return {object} The data object is mutated and returned
+ * @throws {Error} if "Q"/"internal"/"secret" is not configured -- this is an
+ *  outbound credential, and signing it with a guessable machine-derived key
+ *  is worse than not signing at all.
  */
 Utils.sign = function (data, fieldKeys) {
-	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
-	if (!secret) {
-		secret = generateLocalSecret();
-	}
+	var secret = requireInternalSecret();
 	if (!fieldKeys || !fieldKeys.length) {
 		var sf = Q.Config.get(['Q', 'internal', 'sigField'], 'sig');
 		fieldKeys = ['Q.'+sf];

--- a/platform/classes/Q/Utils.js
+++ b/platform/classes/Q/Utils.js
@@ -63,6 +63,28 @@ function generateLocalSecret() {
 		.digest('hex');
 }
 
+/**
+ * Returns the configured Q/internal/secret, or throws.
+ * Mirrors Q_Utils::requireInternalSecret() in PHP, including treating the empty
+ * string and the "TODO: ..." placeholder that local.sample ships as
+ * unconfigured -- that placeholder is published in every copy of this
+ * repository, so an install that keeps it holds a secret every attacker already
+ * has, and can therefore sign with it.
+ * @method requireInternalSecret
+ * @private
+ * @return {string}
+ */
+function requireInternalSecret() {
+	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
+	if (typeof secret === 'string') {
+		secret = secret.trim();
+		if (secret !== '' && secret.substr(0, 5) !== 'TODO:') {
+			return secret;
+		}
+	}
+	throw new Error('Q/internal/secret is not configured');
+}
+
 function ksort(obj) {
 	var i, sorted = {}, keys = Object.keys(obj);
 	keys.sort();
@@ -177,13 +199,19 @@ Utils.sign = function (data, fieldKeys) {
  * @method validate
  * @param {object} data the signed data to validate
  * @param {array} fieldKeys Optionally specify the array key path for the signature field
- * @return {boolean} Whether the signature is valid. Returns true if secret is empty.
+ * @return {boolean} Whether the signature is valid. Returns false (never true)
+ *  when "Q"/"internal"/"secret" is not configured: a validator must not read
+ *  "no key" as "valid". Producing a signature may still fall back to a
+ *  machine-local key (see Utils.signature); accepting one never does.
  */
 Utils.validate = function(data, fieldKeys) {
 	var temp = Q.copy(data, null, 100);
-	var secret = Q.Config.get(['Q', 'internal', 'secret'], null);
-	if (!secret) {
-		secret = generateLocalSecret();
+	var secret;
+	try {
+		secret = requireInternalSecret();
+	} catch (e) {
+		console.warn('Q.Utils.validate: rejecting, ' + e.message);
+		return false;
 	}
 	if (!fieldKeys || !fieldKeys.length) {
 		var sf = Q.Config.get(['Q', 'internal', 'sigField'], 'sig');

--- a/platform/classes/Q/Utils.php
+++ b/platform/classes/Q/Utils.php
@@ -341,6 +341,15 @@ class Q_Utils
 			$secret = Q_Config::get('Q', 'internal', 'secret', null);
 		}
 		if (!isset($secret)) {
+			// Producing a signature, or verifying an artifact we issued
+			// ourselves, may degrade to a machine-local key: it lets nobody
+			// in, and it keeps an install missing the secret serving instead
+			// of 500ing at the door (Q_Session::isValidId() calls this on
+			// every request from Q_Bootstrap::validateEarly()). Accepting a
+			// signature from outside never degrades -- see
+			// Q_Valid::signature() -- and handing one out never does either:
+			// see sign(). The install-time check in Q_Plugin::installApp()
+			// is where a missing secret is meant to be discovered.
 			$secret = Q_Utils::generateLocalSecret();
 		}
 		if (is_array($data)) {
@@ -357,14 +366,15 @@ class Q_Utils
 	 * @param {array|string} [$fieldKeys] Path of the key under which to save signature
 	 * @param {string} [$secret] Can pass a different secret to use for generating the signature
 	 *  than the one found in Q/internal/secret config.}
-	 * @return {array} The data, with the signature added unless $secret is null
+	 * @return {array} The data, with the signature added
+	 * @throws {Q_Exception_MissingConfig} if no $secret is passed and
+	 *  "Q"/"internal"/"secret" is not configured. This is an outbound
+	 *  credential, and signing it with a guessable machine-derived key is
+	 *  worse than not signing at all.
 	 */
 	static function sign($data, $fieldKeys = null, $secret = null) {
 		if (!isset($secret)) {
-			$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		}
-		if (!isset($secret)) {
-			$secret = Q_Utils::generateLocalSecret();
+			$secret = self::requireInternalSecret();
 		}
 		if (!$fieldKeys) {
 			$sf = Q_Config::get('Q', 'internal', 'sigField', 'sig');
@@ -418,6 +428,14 @@ class Q_Utils
 	 */
 	protected static function generateLocalSecret()
 	{
+		// Every input is fixed for the life of the process, and since
+		// Q_Session validates ids through signature() several times per
+		// request, this would otherwise re-read /etc/machine-id (or spawn
+		// `reg query` on Windows) each time.
+		static $secret = null;
+		if (isset($secret)) {
+			return $secret;
+		}
 		$parts = array(
 			gethostname(),
 			PHP_OS,
@@ -439,7 +457,7 @@ class Q_Utils
 			}
 		}
 
-		return hash('sha256', implode("\t", $parts));
+		return $secret = hash('sha256', implode("\t", $parts));
 	}
 
 	/**

--- a/platform/classes/Q/Utils.php
+++ b/platform/classes/Q/Utils.php
@@ -387,6 +387,31 @@ class Q_Utils
 	}
 
 	/**
+	 * Returns the configured "Q"/"internal"/"secret", or throws.
+	 * The empty string and the "TODO: ..." placeholder that local.sample ships
+	 * count as unconfigured -- the placeholder is a fixed value published in
+	 * every copy of this repository, so an install that keeps it holds a secret
+	 * every attacker already has and can therefore sign with.
+	 * @method requireInternalSecret
+	 * @static
+	 * @return {string}
+	 * @throws {Q_Exception_MissingConfig}
+	 */
+	static function requireInternalSecret()
+	{
+		$secret = Q_Config::get('Q', 'internal', 'secret', null);
+		if (is_string($secret)) {
+			$secret = trim($secret);
+			if ($secret !== '' and !Q::startsWith($secret, 'TODO:')) {
+				return $secret;
+			}
+		}
+		throw new Q_Exception_MissingConfig(array(
+			'fieldpath' => 'Q/internal/secret'
+		));
+	}
+
+	/**
 	 * Generate a local secret that is stable but hard to guess from outside
 	 * @method generateLocalSecret
 	 * @static

--- a/platform/classes/Q/Valid.php
+++ b/platform/classes/Q/Valid.php
@@ -337,8 +337,10 @@ class Q_Valid
 	 * @param {array|string} [$fieldKeys] Path of the key under which signature is stored.
 	 *   You can pass a string here instead, which would be the actual signature to test.
 	 * @param {string} [$secret] A different secret to use for generating the signature
-	 * @return {boolean} Whether the phone number seems like it could be valid
+	 * @return {boolean} Whether the signature checked out
 	 * @throws {Q_Exception_FailedValidation}
+	 * @throws {Q_Exception_MissingConfig} if $throwIfInvalid and no $secret is
+	 *  passed and "Q"/"internal"/"secret" is not configured
 	 */
 	static function signature (
 		$throwIfInvalid = false, 
@@ -350,10 +352,22 @@ class Q_Valid
 			$data = $_REQUEST;
 		}
 		if (!isset($secret)) {
-			$secret = Q_Config::get('Q', 'internal', 'secret', null);
-		}
-		if (!isset($secret)) {
-			return true;
+			// Fail CLOSED. This used to `return true` -- with no internal secret
+			// configured, EVERY payload validated, so an unsigned or forged
+			// request passed every gate built on this: handlers/Q/config/validate.php
+			// (which writes config onto the machine), Streams::invites(),
+			// Media/callCenter. A validator must never read "no key" as "valid".
+			// Producing a signature may still fall back to a machine-local key
+			// (see Q_Utils::signature()); accepting one never does.
+			try {
+				$secret = Q_Utils::requireInternalSecret();
+			} catch (Q_Exception_MissingConfig $e) {
+				if ($throwIfInvalid) {
+					Q_Response::code(403);
+					throw $e;
+				}
+				return false;
+			}
 		}
 		$invalid = true;
 		if (is_array($fieldKeys)) {


### PR DESCRIPTION
The producing half of #40, reshaped along the split proposed there: accepting an unsigned request fails closed always (that's https://github.com/Qbix/Platform/pull/54, which this PR is based on — it will show that PR's commit until it merges); producing a signature, or verifying an artifact we issued ourselves, may degrade to a machine-local key without letting anyone in.

## What changes

- **`Q_Utils::sign()` throws** `Q_Exception_MissingConfig` when no secret is passed and `Q/internal/secret` is not configured (or is the shipped placeholder). It hands out an outbound credential; signing that with a guessable key is worse than not signing.
- **`Q_Utils::signature()` keeps `generateLocalSecret()`** as its fallback. It runs from `Q_Session::isValidId()` on every request, from `Q_Bootstrap::validateEarly()`, before any sensible error path — a throw there is a 500 at the door discovered by the first visitor after a deploy. The comment at the fallback says why it is allowed to degrade and where the missing secret is meant to be caught instead.
- **`generateLocalSecret()` memoizes** in a `static`. Inputs are fixed for the life of the process; it now sits on the per-request path several times on an unconfigured install and previously re-read `/etc/machine-id` (or spawned `reg query`) each call. Output unchanged.
- **`Q_Plugin::installApp()` checks the secret up front** and fails with the config path in the message (`<APP_LOCAL_DIR>/app.json` → `Q/internal/secret`), so a missing or placeholder secret is found where an operator can act on it.
- **Same split in `Q/Utils.js`**: `Utils.sign()` throws, `Utils.signature()` keeps the fallback, `generateLocalSecret()` memoizes.

One thing #40's description raised that this shape leaves in place, stated so it isn't lost: `generateLocalSecret()` differs between the PHP host and the Node host, so on an install without a configured secret, PHP↔Node internal signing never verifies. With this PR that is caught at install time rather than at runtime, which is the intended place for it.

Behaviour with a secret configured is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
