### PR TITLE
Drop the unused nodemailer-smtp-transport dependency (2 critical transitive advisories)

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -25,7 +25,6 @@
 		"mysql": "2.16.x",
 		"mysql2": "3.0.0",
 		"nodemailer": "^6.9.13",
-		"nodemailer-smtp-transport": "^2.4.2",
 		"request": "2.x.x",
 		"socket.io": "^4.7.5"
 	},


### PR DESCRIPTION
Drop the unused nodemailer-smtp-transport dependency

`platform/package.json` declares `nodemailer-smtp-transport@^2.4.2`, but
nothing under `platform/` requires it -- the only caller in the whole tree is
`plugins/Users/classes/Users/Email.js`, which declares it in the Users plugin's
own manifest (and stops needing it in Qbix/Users#24).

It is not a harmless stray. It resolves to 2.7.4, which bundles its own
`smtp-connection@2.12.0` -> `httpntlm` -> `underscore@1.7.0`, carrying two
critical advisories:

    GHSA-cf4h-3jhx-xvhq  Arbitrary code execution in underscore
    GHSA-qpx9-hpmf-5gmw  Unbounded recursion in _.flatten / _.isEqual (DoS)

`npm audit` on this manifest alone: 11 vulnerabilities (6 critical) -> 7
(2 critical), and `npm ls underscore smtp-connection httpntlm` goes from that
chain to empty.

Verified by grepping the whole tree for `nodemailer-smtp-transport`: after
Qbix/Users#24 there are no requires of it anywhere.
